### PR TITLE
Show error message if server exits unexpectedly

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -178,7 +178,8 @@ function! s:OnExit(server_name) abort
   elseif old_status == 'exiting'
     let server_info.status= 'exited'
   elseif old_status == 'running'
-    let server_info.status= 'unexpected exit'
+    let server_info.status = 'unexpected exit'
+    call lsc#message#error('Command exited unexpectedly: '.a:server_name)
   endif
   for filetype in keys(g:lsc_server_commands)
     if g:lsc_server_commands[filetype] != a:server_name | continue | endif


### PR DESCRIPTION
I recently tried using this plugin with the Rust language server, but none of the commands did anything. I could run them but got no feedback. The problem turned out to be with RLS: it crashes when initialized with `rootUri` instead of (the now deprecated) `rootPath`.

However, getting no feedback when there's a problem with a server is not helpful. With this patch, an error message is shown if a server crashes, which aids in solving the problem.