### PR TITLE
Allow restarting never started server

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -43,10 +43,10 @@ endfunction
 
 function! lsc#server#restart() abort
   let command = g:lsc_server_commands[&filetype]
-  let server_info = s:servers[command]
-  let old_status = server_info.status
+  let old_status = lsc#server#status(&filetype)
   if old_status == 'starting' || old_status == 'running'
     call lsc#server#kill(&filetype)
+    let server_info = s:servers[command]
     let server_info.status = 'restarting'
   else
     call s:Start(command)


### PR DESCRIPTION
If server failed to start for the first time, s:servers can be empty and lsc#server#restart might fail while trying to access s:servers[command].