### PR TITLE
Add support for metadata/extraFlags to document/didOpen

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -43,6 +43,12 @@ function! s:DidOpen(file_path) abort
       \    'text': buffer_content
       \   }
       \ }
+  if has_key(g:lsc_metadata_extraFlags, filetype)
+    let Func = function(g:lsc_metadata_extraFlags[filetype])
+    let flag = Func(a:file_path, filetype)
+    let params.metadata = {}
+    let params.metadata.extraFlags = flag
+  endif
   if lsc#server#call(filetype, 'textDocument/didOpen', params)
     let s:file_versions[a:file_path] = 1
     let s:file_content[a:file_path] = buffer_content


### PR DESCRIPTION
This is non-standard (yet) extention to LSP allowing to propagate command line flags from the client to the server.

Example message: https://github.com/llvm-mirror/clang-tools-extra/blob/master/test/clangd/extra-flags.test#L10

For more info see: https://github.com/Microsoft/language-server-protocol/issues/255

Usage:

1. In your in .vimrc, define a function accepting file path and language id, returning an array of strings:

    function! Lsc_ClangdExtraFlags(file_path, langid)
        return ["-std=c++2a", "-Wall"]
    endfunction

2. Add its name to g:lsc_metadata_extraFlags

    let g:lsc_metadata_extraFlags = {'cpp' : 'Lsc_ClangdExtraFlags'}

3. Open a file of configured type (C++ in this case)