### PR TITLE
Use keywordprg instead of mapping `K`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.3.2-dev
+
+- `:LSClientShowHover` is now bound with `keywordprg` instead of by mapping `K`.
+  If the `g:lsc_auto_map` manually specifies a binding of `'K'` it should be
+  dropped to pick up the default, or switched to `v:true` to use `keywordprg`
+  instead. If the mapping is set to a string it will continue to be mapped as
+  usual, if it is mapped to `0` or `v:false` no mapping will occur, if it is set
+  to `1` or `v:true` then `keywordprg` will be set. `:LSClientShowHover` also
+  now allows an argument but it will always be ignored.
+
 # 0.3.1
 
 - Allow using the default map but overriding or omitting a subset of the keys.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ matching a search string. Results will populate the quickfix list.
 ### Hover
 
 While the cursor is on any identifier call `LSClientShowHover` (`K` if using the
-default mappings) to request hover text and show it in a preview window.
+default mappings, bound through `keywordprg`) to request hover text and show it
+in a preview window.
 Override the direction of the split by setting `g:lsc_preview_split_direction`
 to either `'below'` or `'above'`.
 

--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -6,7 +6,7 @@ let s:default_maps = {
     \ 'FindImplementations': 'gI',
     \ 'FindCodeActions': 'ga',
     \ 'Rename': 'gR',
-    \ 'ShowHover': 'K',
+    \ 'ShowHover': v:true,
     \ 'DocumentSymbol': 'go',
     \ 'WorkspaceSymbol': 'gS',
     \ 'Completion': 'completefunc',
@@ -53,7 +53,6 @@ function! lsc#config#mapKeys() abort
       \ 'FindImplementations',
       \ 'DocumentSymbol',
       \ 'WorkspaceSymbol',
-      \ 'ShowHover',
       \ 'FindCodeActions',
       \]
     if has_key(l:maps, command)
@@ -67,6 +66,16 @@ function! lsc#config#mapKeys() abort
   endif
   if has_key(l:maps, 'Completion')
     execute 'setlocal '.l:maps['Completion'].'=lsc#complete#complete'
+  endif
+  if has_key(l:maps, 'ShowHover')
+    let l:show_hover = l:maps['ShowHover']
+    if type(l:show_hover) == v:t_bool || type(l:show_hover) == v:t_number
+      if l:show_hover
+        setlocal keywordprg=:LSClientShowHover
+      endif
+    elseif type(l:show_hover) == v:t_string
+      execute 'nnoremap <buffer>'.l:show_hover.' :LSClientShowHover<CR>'
+    endif
   endif
 endfunction
 

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -88,8 +88,8 @@ With |lsc-default-map| this command is bound to "gS".
 Open a |preview| window with hover information corresponding to the element
 under the cursor. Sends a "textDocument/hover" request with the location set
 to the cursor's position. If there is no hover information will show a message
-without opening the preview window. With |lsc-default-map| this command is
-bound to "K".
+without opening the preview window. With |lsc-default-map| the |keywordprg| is
+set to invoke this command.
 
 If the preview window is already visible it will reuse it and maintain layout,
 resizing it only if it is smaller than both |previewheight| and the size of
@@ -210,10 +210,15 @@ enabled for a buffer set the variable "g:lsc_auto_map". Set the value to
 "v:true" to use the defaults |lsc-default-map|, or set to a dict to use
 other keys, or to only map a subset of the commands. Most keys correspond to
 command names, for instance the key "GoToDefinition" creates a mapping for the
-command "LSClientGoToDefinition". Additionally the key "Completion" can choose
-a completefunc to set to the vim-lsc completion function. By default this is
-|completefunc| but it can also be set to |omnifunc| or have no completeion
-function set with an empty value.
+command "LSClientGoToDefinition".
+
+The key "Completion" can choose a completefunc to set to the vim-lsc
+completion function. By default this is |completefunc| but it can also be set
+to |omnifunc| or have no completeion function set with an empty value.
+
+The key "ShowHover" may have a string with a keymap like most other commands,
+or it may be set to `v:true` to set `keywordprg` instead. The default is to
+set `keywordprg`.
 
 To override or unset only a subest of the defaults set the key "defaults" to
 `v:true`. Any keys which have an empty value will not have keys mapped. For
@@ -235,7 +240,7 @@ go                      |:LSClientDocumentSymbol|
 gS                      |:LSClientWorkspaceSymbol|
 ga                      |:LSClientFindCodeActions|
 gR                      |:LSClientRename|
-K                       |:LSClientShowHover|
+|K| (via |keywordprg|)      |:LSClientShowHover|
 
 
 By default the |completefunc| is set to the vim-lsc manual completion

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -16,7 +16,7 @@ command! LSClientFindReferences call lsc#reference#findReferences()
 command! LSClientNextReference call lsc#reference#findNext(1)
 command! LSClientPreviousReference call lsc#reference#findNext(-1)
 command! LSClientFindImplementations call lsc#reference#findImplementations()
-command! LSClientShowHover call lsc#reference#hover()
+command! -nargs=? LSClientShowHover call lsc#reference#hover()
 command! LSClientDocumentSymbol call lsc#reference#documentSymbols()
 command! -nargs=? LSClientWorkspaceSymbol
     \ call lsc#search#workspaceSymbol(<args>)


### PR DESCRIPTION
Closes #101

- If the setting is a boolean and is true, set `keywordprg` instead of
  creating a mapping. Allows setting to `v:false` to opt out entirely.
- If the setting is a string, create a mapping as before. This should be
  backwards compatible with old config specifying a different binding.