### PR TITLE
Add g:lsc_enable_diagnostics config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   usual, if it is mapped to `0` or `v:false` no mapping will occur, if it is set
   to `1` or `v:true` then `keywordprg` will be set. `:LSClientShowHover` also
   now allows an argument but it will always be ignored.
+- Added `g:lsc_enable_dagnostics`. Set to `v:false` to ignore all diagnostics
+  sent by the server.
 
 # 0.3.1
 

--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -74,6 +74,9 @@ function! s:DiagnosticsVersion(file_path) abort
 endfunction
 
 function! lsc#diagnostics#setForFile(file_path, diagnostics) abort
+  if exists('g:lsc_enable_diagnostics') && !g:lsc_enable_diagnostics
+    return
+  endif
   if empty(a:diagnostics) && !has_key(s:file_diagnostics, a:file_path)
     return
   endif

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -183,6 +183,15 @@ automatically close the preview window after completion use the following:
  autocmd CompleteDone * silent! pclose
 <
 
+                                                *lsc-configure-diagnostics*
+                                                *g:lsc_enable_diagnostics*
+Diagnostics highlighting and location list updating is enabled by default. To
+disable diagnostic tracking set `g:lsc_enable_daignostics` to `v:false`. With
+diagnostics disabled |:LSClientAllDiagnostics| will never surface any results.
+The server may communicate diagnostics but they will be ignored. Changing this
+configuration while a server is running may have unexpected results, if it is
+changed use |:LSClientRestartServer|.
+
                                                 *lsc-configure-hover*
                                                 *g:lsc_preview_split_direction*
 By default the `:LSClientShowHover` command splits the window following


### PR DESCRIPTION
Closes #100

Allows disabling all diagnostic functionality by ignoring all
diagnostics sent by the server.