### PR TITLE
Change `documentHighlights` to `documentHighlight`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ requested before the server responds with suggestions.
 
 ### Reference Highlights
 
-If the server supports the `textDocument/documentHighlights` call references to
+If the server supports the `textDocument/documentHighlight` call references to
 the element under the cursor throughout the document will be highlighted.
 Disable with `let g:lsc_reference_highlights = v:false` or customize the
 highlighting with the group `lscReference`. Use `<c-n>`

--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -135,7 +135,7 @@ function! s:setQuickFixSymbols(results) abort
 endfunction
 
 
-" If the server supports `textDocument/documentHighlights` and they are enabled,
+" If the server supports `textDocument/documentHighlight` and they are enabled,
 " use the active highlights to move the cursor to the next or previous referene
 " in the same document to the symbol under the cursor.
 function! lsc#reference#findNext(direction) abort

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -157,8 +157,8 @@ function! s:CheckCapabilities(init_results, server) abort
         endfor
       endif
     endif
-    if has_key(capabilities, 'documentHighlightsProvider')
-      if capabilities['documentHighlightsProvider']
+    if has_key(capabilities, 'documentHighlightProvider')
+      if capabilities['documentHighlightProvider']
         call lsc#cursor#enableReferenceHighlights(filetype)
       endif
     endif


### PR DESCRIPTION
The LSP spec defines `documentHighlight` and
`documentHighlightProvider`, but it looks like this plugin expected
`documentHighlights` (note the plural).

This commit replaces mentions of `documentHighlights` to
`documentHighlight` and `documentHighlightProvider` to
`documentHighlightProvider`.