### PR TITLE
Add support for window/showMessageRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   instead of showing a message.
 - Fix a bug where `au_group_id` was not initialized correctly.
 - Ignore a `null` or empty `insertText` during completion.
+- Add support for `window/showMessageRequest`.
 
 # 0.3.1
 

--- a/autoload/lsc/dispatch.vim
+++ b/autoload/lsc/dispatch.vim
@@ -8,6 +8,13 @@ function! lsc#dispatch#message(server, message) abort
     elseif a:message['method'] ==? 'window/showMessage'
       let params = a:message['params']
       call lsc#message#show(params['message'], params['type'])
+    elseif a:message['method'] ==? 'window/showMessageRequest'
+      let params = a:message['params']
+      let response = lsc#message#showRequest(params['message'], params['actions'])
+      if has_key(a:message, 'id')
+        let id = a:message['id']
+        call a:server.send(lsc#protocol#formatResponse(id, response))
+      endif
     elseif a:message['method'] ==? 'window/logMessage'
       let params = a:message['params']
       call lsc#message#log(params['message'], params['type'])

--- a/autoload/lsc/message.vim
+++ b/autoload/lsc/message.vim
@@ -1,5 +1,20 @@
-function! lsc#message#show(message, ...) abort
+function! lsc#message#show(message) abort
   call s:Echo('echo', a:message, get(a:, 1, 'Log'))
+endfunction
+
+function! lsc#message#showRequest(message, actions) abort
+  let options = [a:message]
+  let index = 0
+  while index < len(a:actions)
+    call add(options, (index + 1) . ' - ' . get(a:actions, index)['title'])
+    let index += 1
+  endwhile
+  let result = inputlist(options)
+  if result <= 0 || result - 1 > len(a:actions)
+    return v:null
+  else
+    return get(a:actions, result - 1)
+  endif
 endfunction
 
 function! lsc#message#log(message, ...) abort


### PR DESCRIPTION
Every possible action is displayed on a separate line, the user has to
enter the number of the matching line. This replies with `v:null` when
the input is invalid or cancelled, following the LSP spec.