### PR TITLE
Support completion items with `MarkupContent`

### DIFF
--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -257,11 +257,14 @@ function! s:CompletionItem(completion_item) abort
       let item.menu = detail_lines[0]
     endif
   endif
+  let item.info = ' '
   if has_key(a:completion_item, 'documentation')
-      \ && a:completion_item.documentation != v:null
-    let item.info = a:completion_item.documentation
-  else
-    let item.info = ' '
+    let documentation = a:completion_item.documentation
+    if type(documentation) == v:t_string
+      let item.info = documentation
+    elseif type(documentation) == v:t_dict && has_key(documentation, 'value')
+      let item.info = documentation.value
+    endif
   endif
   return item
 endfunction


### PR DESCRIPTION
> The documentation attached to completion items can be either a string or
a `MarkupContent`. To make sure that a value was actually present, we
used to compare the value of the `documentation` of a completion item
against `v:null`, which would throw an error when the value is present
and is a dictionary (representing the `MarkupContent`).

> When a `MarkupContent` is present, we take its `value` and use this as
the completion `info`. We ignore the `kind`.

It looks like comparing the types when documentation is `v:null` is not a problem. We cannot compare `documentation` and `v:null` directly, because if `documentation` is a dictionary, then an error would be thrown.