### PR TITLE
Fix `initialized` typo

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -116,7 +116,7 @@ function! s:Start(server) abort
     for filetype in a:server.filetypes
       call lsc#file#trackAll(filetype)
     endfor
-    call s:Call(a:server, 'initalized', {})
+    call s:Call(a:server, 'initialized', {})
   endfunction
   if exists('g:lsc_trace_level') &&
       \ index(['off', 'messages', 'verbose'], g:lsc_trace_level) >= 0


### PR DESCRIPTION
Follow-up on https://github.com/natebosch/vim-lsc/issues/113