### PR TITLE
fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ let g:lsc_auto_map = {
     \ 'DocumentSymbol': 'go',
     \ 'WorkspaceSymbol': 'gS',
     \ 'ShowHover': 'v:true',
-    \ 'SignatureHelp', '<C-m>',
+    \ 'SignatureHelp': '<C-m>',
     \ 'Completion': 'completefunc',
     \}
 ```


### PR DESCRIPTION
This is a really small change, but if you would put those settings in your .vimrc you'd get a warning. This is the correct format.