### PR TITLE
Line-wrap long diagnostics and auto-update cmdheight.

### DIFF
--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -30,7 +30,14 @@ function! lsc#cursor#showDiagnostic() abort
   let l:diagnostic = lsc#diagnostics#underCursor()
   if has_key(l:diagnostic, 'message')
     let l:max_width = &columns - 18
-    let l:message = strtrans(l:diagnostic.message)
+    " Count lines of message
+    let l:msg_height = strlen(substitute(l:diagnostic.message, "[^\n]", "","g")) + 1
+    " If the message has more lines than the current cmdheight, escape newlines
+    if l:msg_height > &cmdheight
+        let l:message = strtrans(l:diagnostic.message)
+    else
+        let l:message = l:diagnostic.message
+    end
     if strdisplaywidth(l:message) > l:max_width
       let l:truncated = strcharpart(l:message, 0, l:max_width)
       " Trim by character until a satisfactory display width.


### PR DESCRIPTION
Followup of #124. Fixes #123.

Previously, diagnostic messages were processed with `strtrans` and
displayed on a single-line making it difficult to understand long
multi-line diagnostics.

With this commit, we line-wrap long multi-line messages so that they fit
within the editor maximum width and automatically adjusts the
`cmdheight` variable to ensure that there's enough vertical space to
display the message.

We make sure to preserve newlines in the original message even if that
can produce unexpected line wrapping. For example,
```
// Before
// ----------
The quick brown
fox jumps.

// After
// ----------
The quick
brown
fox jumps.

// Expected
// ----------
The quick
brown fox
jumps.
```

![2018-12-15 13 00 39](https://user-images.githubusercontent.com/1408093/50043345-b1287080-0072-11e9-8e62-b5fa074da0fa.gif)
