### PR TITLE
Add special handling for window/progress messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix a bug with responding to `window/showMessage` notifications.
 - Wait to call 'exit' until the 'shutdown' response comes back.
 - Update tag stack when jumping to definition.
+- Add special handling for window/progress messages
 
 # 0.3.1
 

--- a/autoload/lsc/dispatch.vim
+++ b/autoload/lsc/dispatch.vim
@@ -18,6 +18,15 @@ function! lsc#dispatch#message(server, message) abort
     elseif a:message['method'] ==? 'window/logMessage'
       let params = a:message['params']
       call lsc#message#log(params['message'], params['type'])
+    elseif a:message['method'] ==? 'window/progress'
+      let params = a:message['params']
+      if has_key(params, 'message')
+        call lsc#message#log('Progress ' . params['title'] . params['message'])
+      elseif has_key(params, 'done')
+        call lsc#message#log('Finished ' . params['title'])
+      else
+        call lsc#message#log('Starting ' . params['title'])
+      endif
     elseif a:message['method'] ==? 'workspace/applyEdit'
       let params = a:message['params']
       let applied = lsc#edit#apply(params.edit)


### PR DESCRIPTION
This commit adds a message handler for "window/progress" messages such as the ones I got from the Rust Language Server 1.31.0 (https://github.com/rust-lang/rls).

Fixes #129.