### PR TITLE
Set exit status before calling exit

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -62,8 +62,8 @@ endfunction
 " was made because the server is not currently running.
 function! s:Kill(server, status, OnExit) abort
   function! Exit(result) closure abort
-    call s:Call(a:server, 'exit', v:null)
     let a:server.status = a:status
+    call s:Call(a:server, 'exit', v:null, v:true)
     if a:OnExit != v:null | call a:OnExit() | endif
   endfunction
   return s:Call(a:server, 'shutdown', v:null, function('Exit'))


### PR DESCRIPTION
Fixes #127 (hopefully)

If the server process exits very quickly after the `exit` request it's
possible that the `on_exit` handler is triggering before the flush is
finished which would make it appear in the handler that the process
exited before it was called. Set the new status and force the `exit`
request on an apparently not-running server to avoid this bad ordering.