### PR TITLE
Allow filtering echoed logs by level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add special handling for window/progress messages
 - Add `:LSClientLineDiagnostics` to print diagnostics for the current line.
 - Allow server commands to be specified as lists.
+- Allow filtering what level of logs are echoed.
 
 # 0.3.1
 

--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -144,10 +144,10 @@ endfunction
 
 " Whether a message of type [type] should be echoed
 "
-" By default messages are shown at "Warning" or "Error", this can be overrided
-" per server.
+" By default messages are shown at "Info" or higher, this can be overrided per
+" server.
 function! lsc#config#shouldEcho(server, type) abort
-  let l:threshold = 2
+  let l:threshold = 3
   if has_key(a:server.config, 'log_level')
     if type(a:server.config.log_level) == v:t_number
       let l:threshold = a:server.config.log_level

--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -141,3 +141,28 @@ function! s:HasFunction(hook) abort
   endfor
   return v:false
 endfunction
+
+" Whether a message of type [type] should be echoed
+"
+" By default messages are shown at "Warning" or "Error", this can be overrided
+" per server.
+function! lsc#config#shouldLog(server, type) abort
+  let l:threshold = 2
+  if has_key(a:server.config, 'log_level')
+    if type(a:server.config.log_level) == v:t_number
+      let l:threshold = a:server.config.log_level
+    else
+      let l:config = a:server.config.log_level
+      if l:config == 'Error'
+        let l:threshold = 1
+      elseif l:config == 'Warning'
+        let l:threshold = 2
+      elseif l:config == 'Info'
+        let l:threshold = 3
+      elseif l:config == 'Log'
+        let l:threshold = 4
+      endif
+    endif
+  endif
+  return a:type <= l:threshold
+endfunction

--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -146,7 +146,7 @@ endfunction
 "
 " By default messages are shown at "Warning" or "Error", this can be overrided
 " per server.
-function! lsc#config#shouldLog(server, type) abort
+function! lsc#config#shouldEcho(server, type) abort
   let l:threshold = 2
   if has_key(a:server.config, 'log_level')
     if type(a:server.config.log_level) == v:t_number

--- a/autoload/lsc/dispatch.vim
+++ b/autoload/lsc/dispatch.vim
@@ -7,7 +7,7 @@ function! lsc#dispatch#message(server, message) abort
       call lsc#diagnostics#setForFile(file_path, params['diagnostics'])
     elseif a:message['method'] ==? 'window/showMessage'
       let params = a:message['params']
-      call lsc#message#log(params['message'], params['type'])
+      call lsc#message#show(params['message'], params['type'])
     elseif a:message['method'] ==? 'window/showMessageRequest'
       let params = a:message['params']
       let response = lsc#message#showRequest(params['message'], params['actions'])
@@ -17,15 +17,15 @@ function! lsc#dispatch#message(server, message) abort
       endif
     elseif a:message['method'] ==? 'window/logMessage'
       let params = a:message['params']
-      call lsc#message#log(params['message'], params['type'])
+      call a:server.log(params['message'], params['type'])
     elseif a:message['method'] ==? 'window/progress'
       let params = a:message['params']
       if has_key(params, 'message')
-        call lsc#message#log('Progress ' . params['title'] . params['message'])
+        call lsc#message#show('Progress ' . params['title'] . params['message'])
       elseif has_key(params, 'done')
-        call lsc#message#log('Finished ' . params['title'])
+        call lsc#message#show('Finished ' . params['title'])
       else
-        call lsc#message#log('Starting ' . params['title'])
+        call lsc#message#show('Starting ' . params['title'])
       endif
     elseif a:message['method'] ==? 'workspace/applyEdit'
       let params = a:message['params']

--- a/autoload/lsc/message.vim
+++ b/autoload/lsc/message.vim
@@ -17,12 +17,12 @@ function! lsc#message#showRequest(message, actions) abort
   endif
 endfunction
 
-function! lsc#message#log(message, ...) abort
-  call s:Echo('echom', a:message, get(a:, 1, 'Log'))
+function! lsc#message#log(message, type) abort
+  call s:Echo('echom', a:message, a:type)
 endfunction
 
 function! lsc#message#error(message) abort
-  call lsc#message#log(a:message, 'Error')
+  call s:Echo('echom', a:message, 'Error')
 endfunction
 
 function! s:Echo(echo_cmd, message, level) abort

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -14,6 +14,7 @@ if !exists('s:initialized')
   " - messages. The last 10 messages from the server
   " - init_result. The response to the initialization call
   " - filetypes. List of filetypes handled by this server.
+  " - logs. The last 100 logs from `window/logMessage`.
   " - config. Config dict. Contains:
   "   - name: Same as the key into `s:servers`
   "   - command: Executable
@@ -279,6 +280,7 @@ function! lsc#server#register(filetype, config) abort
       \ 'status': initial_status,
       \ 'calls': [],
       \ 'messages': [],
+      \ 'logs': [],
       \ 'filetypes': [a:filetype],
       \ 'config': config,
       \ 'send_buffer': '',
@@ -292,6 +294,12 @@ function! lsc#server#register(filetype, config) abort
   function server.callback(message) abort
     let self.buffer .= a:message
     call lsc#protocol#consumeMessage(self)
+  endfunction
+  function server.log(message, type) abort
+    if lsc#config#shouldLog(self, a:type)
+      call lsc#message#log(a:message, a:type)
+    endif
+    call lsc#util#shift(self.logs, 100, {'message': a:message, 'type': a:type})
   endfunction
   function server.err_callback(message) abort
     if self.status == 'starting'
@@ -325,7 +333,6 @@ function! lsc#server#register(filetype, config) abort
     if l:old_status == 'restarting'
       call s:Start(self)
     endif
-
   endfunction
   let s:servers[config.name] = server
 endfunction

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -296,7 +296,7 @@ function! lsc#server#register(filetype, config) abort
     call lsc#protocol#consumeMessage(self)
   endfunction
   function server.log(message, type) abort
-    if lsc#config#shouldLog(self, a:type)
+    if lsc#config#shouldEcho(self, a:type)
       call lsc#message#log(a:message, a:type)
     endif
     call lsc#util#shift(self.logs, 100, {'message': a:message, 'type': a:type})

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -365,6 +365,12 @@ are configured with the same name use the same server.
 `'enabled'`: Set to `v:false` to avoid starting the server until
 |:LSClientEnable| is called.
 
+                                                *lsc-server-log_level*
+`'log_level'`: May be one of `'Error'`, `'Warning'`, `Info`, or `'Log'`.
+Default `'Warning'`. Messages through `window/logMessage` will only be echoed
+if they are at this level or "above". With the default value of `'Warning'`
+only `'Error'` and `'Warning'` messages are shown.
+
                                                 *lsc-server-suppress_stderr*
 `'suppress_stderr'`: Set to `v:true` to suppress stderr output which is
 received after the server has been initialized. Stderr output before

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -366,10 +366,11 @@ are configured with the same name use the same server.
 |:LSClientEnable| is called.
 
                                                 *lsc-server-log_level*
-`'log_level'`: May be one of `'Error'`, `'Warning'`, `Info`, or `'Log'`.
-Default `'Warning'`. Messages through `window/logMessage` will only be echoed
-if they are at this level or "above". With the default value of `'Warning'`
-only `'Error'` and `'Warning'` messages are shown.
+`'log_level'`: May be one of `'Error'`, `'Warning'`, `'Info'`, or `'Log'`.
+Default `'Info'`. Messages through `window/logMessage` will only be echoed
+if they are at this level or above. With the default value of `'Info'`
+only `'Log'` messages are suppressed. Set to `-1` to disable echo for any
+message.
 
                                                 *lsc-server-suppress_stderr*
 `'suppress_stderr'`: Set to `v:true` to suppress stderr output which is


### PR DESCRIPTION
Fixes #133

Add a per-server configuration option `log_level` which filters the log
messages that are echoed directly. All message regardless of level are
shifted into a new `server.logs` field. Eventually this could be used
for additional debugging or writing to a file.