### PR TITLE
Mark completion item as case insensitive

### DIFF
--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -236,7 +236,7 @@ endfunction
 " `label` is always expected to be set and is used as the `abbr` shown in the
 " popupmenu. This may be different from the inserted text.
 function! s:CompletionItem(completion_item) abort
-  let item = {'abbr': a:completion_item.label, 'dup': 1}
+  let item = {'abbr': a:completion_item.label, 'icase': 1, 'dup': 1}
   if has_key(a:completion_item, 'textEdit')
       \ && type(a:completion_item.textEdit) == v:t_dict
       \ && has_key(a:completion_item.textEdit, 'newText')


### PR DESCRIPTION
Without this, `addev` is not matched with `addEventListener`