### PR TITLE
Manually expand paths to missing directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Allow filtering what level of logs are echoed.
 - Fix a bug with incremental text change syncing when there are multi-byte
   characters in the buffer.
+- Fix some bugs with editing in a buffer for a file which has not been written,
+  and would be written to a directory that does not exist.
 
 # 0.3.1
 

--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -109,7 +109,7 @@ function! lsc#diagnostics#setForFile(file_path, diagnostics) abort
   endif
   call lsc#diagnostics#updateLocationList(a:file_path)
   call lsc#highlights#updateDisplayed()
-  if(a:file_path ==# expand('%:p'))
+  if(a:file_path ==# lsc#file#fullPath())
     call lsc#cursor#showDiagnostic()
   endif
 endfunction
@@ -232,7 +232,7 @@ endfunction
 " no diagnostic is directly under the cursor returns the last seen diagnostic
 " on this line.
 function! lsc#diagnostics#underCursor() abort
-  let file_diagnostics = lsc#diagnostics#forFile(expand('%:p'))
+  let file_diagnostics = lsc#diagnostics#forFile(lsc#file#fullPath())
   let line = line('.')
   if !has_key(file_diagnostics, line)
     return {}
@@ -267,7 +267,7 @@ function! lsc#diagnostics#forLine(file, line) abort
 endfunction
 
 function! lsc#diagnostics#echoForLine() abort
-  let l:file_diagnostics = lsc#diagnostics#forFile(expand('%:p'))
+  let l:file_diagnostics = lsc#diagnostics#forFile(lsc#file#fullPath())
   let l:line = line('.')
   if !has_key(l:file_diagnostics, l:line)
     echo 'No diagnostics'

--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -29,7 +29,7 @@ endfunction
 function! lsc#diagnostics#clean(filetype) abort
   for buffer in getbufinfo({'loaded': v:true})
     if getbufvar(buffer.bufnr, '&filetype') != a:filetype | continue | endif
-    call lsc#diagnostics#setForFile(buffer.name, [])
+    call lsc#diagnostics#setForFile(lsc#file#normalize(buffer.name), [])
   endfor
 endfunction
 
@@ -125,7 +125,7 @@ endfunction
 
 " Updates location list for all windows showing [file_path].
 function! lsc#diagnostics#updateLocationList(file_path) abort
-  let bufnr = bufnr(a:file_path)
+  let bufnr = lsc#file#bufnr(a:file_path)
   if bufnr == -1 | return | endif
   let file_ref = {'bufnr': bufnr}
   let diagnostics_version = s:DiagnosticsVersion(a:file_path)
@@ -194,7 +194,7 @@ endfunction
 function! lsc#diagnostics#showInQuickFix() abort
   let all_diagnostics = []
   for file_path in keys(s:file_diagnostics)
-    let bufnr = bufnr(file_path)
+    let bufnr = lsc#file#bufnr(file_path)
     if bufnr == -1
       let file_ref = {'filename': fnamemodify(file_path, ':.')}
     else

--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -119,7 +119,7 @@ endfunction
 function! s:ApplyAll(changes) abort
   for [uri, edits] in items(a:changes)
     let l:file_path = lsc#uri#documentPath(uri)
-    let l:bufnr = bufnr(l:file_path)
+    let l:bufnr = lsc#file#bufnr(l:file_path)
     let l:cmd = 'keepjumps keepalt'
     if l:bufnr !=# -1
       let l:cmd .= ' b '.l:bufnr

--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -7,7 +7,7 @@ function! lsc#edit#findCodeActions(...) abort
   call lsc#file#flushChanges()
   let params = lsc#params#documentRange()
   let params.context = {'diagnostics':
-      \ lsc#diagnostics#forLine(expand('%:p'), line('.'))}
+      \ lsc#diagnostics#forLine(lsc#file#fullPath(), line('.'))}
   call lsc#server#userCall('textDocument/codeAction', params,
       \ lsc#util#gateResult('CodeActions', function('<SID>SelectAction'),
       \     v:null, [ActionFilter]))

--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -168,7 +168,7 @@ function! lsc#file#fullPath() abort
   let l:file_path = expand('%:p')
   if l:file_path ==# expand('%')
     " Path could not be expanded due to pointing to a non-existent directory
-    let l:file_path = getcwd().'/'.l:file_path
+    let l:file_path = lsc#file#normalize(getbufinfo('%')[0].name)
   endif
   return l:file_path
 endfunction

--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -164,6 +164,9 @@ endfunction
 " The association between a buffer and full path may change if the file has not
 " been written yet - this makes a best-effort attempt to get a full path anyway.
 " In most cases if the working directory doesn't change this isn't harmful.
+"
+" Paths which do need to be manually normalized are stored so that the full path
+" can be associated back to a buffer with `lsc#file#bufnr()`.
 function! lsc#file#fullPath() abort
   let l:file_path = expand('%:p')
   if l:file_path ==# expand('%')
@@ -173,6 +176,8 @@ function! lsc#file#fullPath() abort
   return l:file_path
 endfunction
 
+" Like `bufnr()` but handles the case where a relative path was normalized
+" against cwd.
 function! lsc#file#bufnr(file_path) abort
   let l:bufnr = bufnr(a:file_path)
   if l:bufnr == -1 && has_key(s:normalized_paths, a:file_path)
@@ -181,6 +186,7 @@ function! lsc#file#bufnr(file_path) abort
   return l:bufnr
 endfunction
 
+" If `buffer_name` is relative, normalize it against `cwd`.
 function! lsc#file#normalize(buffer_name) abort
   if a:buffer_name[0] ==# '/' | return a:buffer_name | endif
   let l:full_path = getcwd().'/'.a:buffer_name

--- a/autoload/lsc/highlights.vim
+++ b/autoload/lsc/highlights.vim
@@ -14,7 +14,7 @@ function! lsc#highlights#update() abort
   if s:CurrentWindowIsFresh() | return | endif
   call lsc#highlights#clear()
   if &diff | return | endif
-  for line in values(lsc#diagnostics#forFile(expand('%:p')))
+  for line in values(lsc#diagnostics#forFile(lsc#file#fullPath()))
     for diagnostic in line
       let match = matchaddpos(diagnostic.group, diagnostic.ranges, -1)
       call add(w:lsc_diagnostic_matches, match)

--- a/autoload/lsc/highlights.vim
+++ b/autoload/lsc/highlights.vim
@@ -11,10 +11,9 @@ endfunction
 
 " Refresh highlight matches in the current window.
 function! lsc#highlights#update() abort
-  if s:CurrentWindowIsFresh() | echom 'Fresh!' | return | endif
+  if s:CurrentWindowIsFresh() | return | endif
   call lsc#highlights#clear()
   if &diff | return | endif
-  echom 'Querying for diagnostics for: '.lsc#file#fullPath()
   for line in values(lsc#diagnostics#forFile(lsc#file#fullPath()))
     for diagnostic in line
       let match = matchaddpos(diagnostic.group, diagnostic.ranges, -1)

--- a/autoload/lsc/highlights.vim
+++ b/autoload/lsc/highlights.vim
@@ -11,9 +11,10 @@ endfunction
 
 " Refresh highlight matches in the current window.
 function! lsc#highlights#update() abort
-  if s:CurrentWindowIsFresh() | return | endif
+  if s:CurrentWindowIsFresh() | echom 'Fresh!' | return | endif
   call lsc#highlights#clear()
   if &diff | return | endif
+  echom 'Querying for diagnostics for: '.lsc#file#fullPath()
   for line in values(lsc#diagnostics#forFile(lsc#file#fullPath()))
     for diagnostic in line
       let match = matchaddpos(diagnostic.group, diagnostic.ranges, -1)

--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -85,7 +85,7 @@ function! s:QuickFixItem(location) abort
 endfunction
 
 function! s:goTo(file, line, character) abort
-  if a:file != expand('%:p')
+  if a:file != lsc#file#fullPath()
     let relative_path = fnamemodify(a:file, ':~:.')
     exec 'edit '.relative_path
     " 'edit' already left a jump

--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -75,7 +75,7 @@ function! s:QuickFixItem(location) abort
       \ 'col': a:location.range.start.character + 1}
   let file_path = lsc#uri#documentPath(a:location.uri)
   let item.filename = fnamemodify(file_path, ':.')
-  let bufnr = bufnr(file_path)
+  let bufnr = lsc#file#bufnr(file_path)
   if bufnr != -1 && bufloaded(bufnr)
     let item.text = getbufline(bufnr, item.lnum)[0]
   else

--- a/autoload/lsc/uri.vim
+++ b/autoload/lsc/uri.vim
@@ -1,10 +1,10 @@
 function! lsc#uri#documentUri(...) abort
   if a:0 >= 1
-    let file_path = a:1
+    let l:file_path = a:1
   else
-    let file_path = expand('%:p')
+    let l:file_path = lsc#file#fullPath()
   endif
-  return s:filePrefix().s:EncodePath(file_path)
+  return s:filePrefix().s:EncodePath(l:file_path)
 endfunction
 
 function! lsc#uri#documentPath(uri) abort

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -33,10 +33,9 @@ endfunction
 " Returns the window IDs of the windows showing the buffer opened for
 " [file_path].
 function! lsc#util#windowsForFile(file_path) abort
-  let bufinfo = getbufinfo(a:file_path)
-  if len(bufinfo) < 1
-    return []
-  endif
+  let l:bufnr = lsc#file#bufnr(a:file_path)
+  if l:bufnr == -1 | return [] | endif
+  let bufinfo = getbufinfo(l:bufnr)
   return copy(bufinfo[0].windows)
 endfunction
 

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -127,7 +127,7 @@ function! LSCEnsureCurrentWindowState() abort
     endif
     return
   endif
-  call lsc#diagnostics#updateLocationList(expand('%:p'))
+  call lsc#diagnostics#updateLocationList(lsc#file#fullPath())
   call lsc#highlights#update()
   call lsc#cursor#onWinEnter()
 endfunction


### PR DESCRIPTION
Fixes #138

The best guess for the full path of a relative path buffer in a
non-existent directory is to base it off the `cwd`. This matches the
behavior of the `:p` modifier if the buffer is for a file that does not
exist, but would be in an existing directory.

Buffers that have not been written are not associated with a file. For
these buffers, when the `cwd` changes the apparent full path will also
change. This is true whether using the `:p` modifier, or the new guess
based on `cwd`.

- Add a utility `lsc#file#fullPath()` to incorporate this normalization
  against `cwd` when necessary.
- Update every place using `expand('%:p')` to call this new utility
  instead.