### PR TITLE
Populate user_data with snippet metadata

### DIFF
--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -246,6 +246,12 @@ function! s:CompletionItem(completion_item) abort
   else
     let item.word = a:completion_item.label
   endif
+  if has_key(a:completion_item, 'insertTextFormat') && a:completion_item.insertTextFormat == 2
+    let item.user_data = json_encode({
+          \ 'snippet': item.word,
+          \ 'snippet_trigger': item.word
+          \ })
+  endif
   if has_key(a:completion_item, 'kind')
     let item.kind = s:CompletionItemKind(a:completion_item.kind)
   endif

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -214,7 +214,9 @@ function! s:ClientCapabilities() abort
     \     'didSave': v:false,
     \   },
     \   'completion': {
-    \     'snippetSupport': v:false,
+    \     'completionItem': {
+    \       'snippetSupport': g:lsc_enable_snippet_support,
+    \      },
     \   },
     \   'definition': {'dynamicRegistration': v:false},
     \   'codeAction': {

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -315,6 +315,14 @@ be smaller than with full syncs.
 By default the client will modify buffers in response to `workspace/applyEdit`
 messages. To disable edits set `g:lsc_enable_apply_edit` to `v:false`.
 
+                                                *lsc-snippet-support*
+                                                *g:lsc_enable_snippet_support*
+By default the client disables support for snippets as insert text. If set to
+`v:true` and supported by the server, insert text may contain snippets.
+
+Autocompletion of snippets requires a plugin that can complete using
+`user_data` on `CompleteDone`, such as neosnippet.vim
+
                                                 *lsc-configure-references*
                                                 *g:lsc_reference_highlights*
 By default the client will highlight references to the element under the

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -13,6 +13,9 @@ endif
 if !exists('g:lsc_auto_completeopt')
   let g:lsc_auto_completeopt = v:true
 endif
+if !exists('g:lsc_enable_snippet_support')
+  let g:lsc_enable_snippet_support = v:false
+endif
 
 command! LSClientGoToDefinition call lsc#reference#goToDefinition()
 command! LSClientFindReferences call lsc#reference#findReferences()


### PR DESCRIPTION
If the langserver returns a snippet ([`insertTextFormat == 2`](https://microsoft.github.io/language-server-protocol/specification#textDocument_completion)), populating the `user_data` in vim/neovim will allow snippet managers like [neosnippet](https://github.com/Shougo/neosnippet.vim/blob/f7755084699db69ce9ff51c87baf8e639b7e543a/autoload/neosnippet/mappings.vim#L166-L175) to trigger snippet completion.

[![demo](https://asciinema.org/a/yyHjExpQyu5piYI8TY9uxf7jL.svg)](https://asciinema.org/a/yyHjExpQyu5piYI8TY9uxf7jL)

```viml
let g:neosnippet#enable_completed_snippet = 1
autocmd CompleteDone * call neosnippet#complete_done()
```