### PR TITLE
Fix default value of g:lsc_auto_map in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ let g:lsc_auto_map = {
     \ 'PreviousReference': '<C-p>',
     \ 'FindImplementations': 'gI',
     \ 'FindCodeActions': 'ga',
+    \ 'Rename': 'gR',
+    \ 'ShowHover': v:true,
     \ 'DocumentSymbol': 'go',
     \ 'WorkspaceSymbol': 'gS',
-    \ 'ShowHover': 'v:true',
     \ 'SignatureHelp': '<C-m>',
     \ 'Completion': 'completefunc',
     \}


### PR DESCRIPTION
`Rename` was missing, and `ShowHover` was a string instead of a bool.