### PR TITLE
Improve GoToDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   characters in the buffer.
 - Fix some bugs with editing in a buffer for a file which has not been written,
   and would be written to a directory that does not exist.
+- Add `:LSClientGoToDefinitionSplit` to go to definitions in a split window
+  (depending on `switchbuf`).
 
 # 0.3.1
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ let g:lsc_auto_map = v:true " Use defaults
 " ... or set only the keys you want mapped, defaults are:
 let g:lsc_auto_map = {
     \ 'GoToDefinition': '<C-]>',
+    \ 'GoToDefinitionSplit': ['<C-W>]', '<C-W><C-]>'],
     \ 'FindReferences': 'gr',
     \ 'NextReference': '<C-n>',
     \ 'PreviousReference': '<C-p>',

--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -1,5 +1,6 @@
 let s:default_maps = {
     \ 'GoToDefinition': '<C-]>',
+    \ 'GoToDefinitionSplit': ['<C-W>]', '<C-W><C-]>'],
     \ 'FindReferences': 'gr',
     \ 'NextReference': '<C-n>',
     \ 'PreviousReference': '<C-p>',
@@ -48,24 +49,25 @@ function! lsc#config#mapKeys() abort
 
   for command in [
       \ 'GoToDefinition',
+      \ 'GoToDefinitionSplit',
       \ 'FindReferences',
       \ 'NextReference',
       \ 'PreviousReference',
       \ 'FindImplementations',
+      \ 'FindCodeActions',
+      \ 'ShowHover',
       \ 'DocumentSymbol',
       \ 'WorkspaceSymbol',
-      \ 'FindCodeActions',
       \ 'SignatureHelp',
-      \]
-    if has_key(l:maps, command)
-      execute 'nnoremap <buffer>'.l:maps[command].' :LSClient'.command.'<CR>'
+      \] + (get(g:, 'lsc_enable_apply_edit', 1) ? ['Rename'] : [])
+    let lhs = get(l:maps, command, v:none)
+    if type(lhs) != v:t_string && type(lhs) != v:t_list
+      continue
     endif
+    for m in type(lhs) == v:t_list ? lhs : [lhs]
+      execute 'nnoremap <buffer>'.m.' :LSClient'.command.'<CR>'
+    endfor
   endfor
-  if !exists('g:lsc_enable_apply_edit') || g:lsc_enable_apply_edit
-    if has_key(l:maps, 'Rename')
-      execute 'nnoremap <buffer>'.l:maps['Rename'].' :LSClientRename<CR>'
-    endif
-  endif
   if has_key(l:maps, 'Completion')
     execute 'setlocal '.l:maps['Completion'].'=lsc#complete#complete'
   endif
@@ -75,8 +77,6 @@ function! lsc#config#mapKeys() abort
       if l:show_hover
         setlocal keywordprg=:LSClientShowHover
       endif
-    elseif type(l:show_hover) == v:t_string
-      execute 'nnoremap <buffer>'.l:show_hover.' :LSClientShowHover<CR>'
     endif
   endif
 endfunction

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -52,13 +52,28 @@ Jump to the location defining the element under the cursor. Sends a
 "textDocument/definition" request with the location set to the cursor's
 position. If the cursor is not in the same position when the server responds
 the jump will be canceled. With |lsc-default-map| this command is bound to
-<c-]>.
+`<c-]>`.
 
 If this version of vim supports |settagstack| the tag stack will also be
 updated to include this jump. Jump back with `<c-t>` or |:pop|, it is not
 possible to jump forward in the taglist when navigating with this client. The
 jump will always be present in the |jumplist|, jump back with `<c-o>` or
 forward with `<c-i>`.
+
+                                                *:LSClientGoToDefinitionSplit*
+Like |LSClientGoToDefinition|, except go to the location in a split,
+respecting the 'switchbuf' option. With |lsc-default-map| this command is
+bound to `<c-w>]` and `<c-w><c-]>`.
+
+You can use this command with |mods|, for example, >
+
+    :vertical LSClientGoToDefinitionSplit
+<
+will default to opening a vertical split, while >
+
+    :tab LSClientGoToDefinitionSplit
+<
+will prefer a new tab.
 
                                                 *:LSClientFindReferences*
 Populate the |quickfix| with a list of location which reference the element
@@ -281,6 +296,7 @@ other defaults set this to:
 The default mapping for keys, if you've opted in to "g:lsc_auto_map" are:
 
 <C-]>                   |:LSClientGoToDefinition|
+<C-W>], <C-W><C-]>      |:LSClientGoToDefinitionSplit|
 gr                      |:LSClientFindReferences|
 <C-n>                   |:LSClientNextReference|
 <C-p>                   |:LSClientPreviousReference|

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -14,7 +14,10 @@ if !exists('g:lsc_auto_completeopt')
   let g:lsc_auto_completeopt = v:true
 endif
 
-command! LSClientGoToDefinition call lsc#reference#goToDefinition()
+command! LSClientGoToDefinitionSplit
+    \ call lsc#reference#goToDefinition(<q-mods>, 1)
+command! LSClientGoToDefinition
+    \ call lsc#reference#goToDefinition(<q-mods>, 0)
 command! LSClientFindReferences call lsc#reference#findReferences()
 command! LSClientNextReference call lsc#reference#findNext(1)
 command! LSClientPreviousReference call lsc#reference#findNext(-1)


### PR DESCRIPTION
This PR aims to address a few very minor annoyances I had with the GoToDefinition command:

1) Add `:LSClientGoToDefinitionSplit` for opening in a split instead of the current window.  This can be used with modifiers such as
 
            :vertical LSClientGoToDefinitionSplit
            :tab LSClientGoToDefinitionSplit

2) Improve tagstack handling.  Obeys `<c-t>` and puts the new tag in the correct place in the stack[*].

3) When going to a definition in another file, also set curswant so cursor doesn't unexpectedly jump after moving.

[*] vim's tag stack is interesting.  When you jump to a tag, everything "newer" than your current index gets popped off the stack.  That is, including the current index- the arrow on the `:tags` list is not where you are but where `:tag` (i.e., a push) will bring you, hence usually the current index is placed one off of the stack ready to accept a new tag.  The current lsc implementation simply appends to the stack always, regardless of current index.

When opening tags in a split via `:stag` or `<c-w><c-]>` the new tag gets pushed onto the stack prior to making the split, so that both windows have the same tagstack (using normal vim split rules), and only then does the current index get incremented in the destination window.  In the end both windows have the same stack and differ only by index.



