### PR TITLE
config: fix undefined varible `v:none` on neovim

### DIFF
--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -60,7 +60,7 @@ function! lsc#config#mapKeys() abort
       \ 'WorkspaceSymbol',
       \ 'SignatureHelp',
       \] + (get(g:, 'lsc_enable_apply_edit', 1) ? ['Rename'] : [])
-    let lhs = get(l:maps, command, v:none)
+    let lhs = get(l:maps, command, [])
     if type(lhs) != v:t_string && type(lhs) != v:t_list
       continue
     endif


### PR DESCRIPTION
`v:none` does not exist in neovim (see `:help v:none` in neovim)