### PR TITLE
Execute `update` after apply changes to buffer

### DIFF
--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -130,6 +130,7 @@ function! s:ApplyAll(changes) abort
       let l:cmd .= ' | execute "keepjumps normal! '.s:Apply(edit).'"'
     endfor
     execute l:cmd
+    execute 'update'
     call lsc#file#onChange(l:file_path)
   endfor
 endfunction

--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -130,7 +130,7 @@ function! s:ApplyAll(changes) abort
       let l:cmd .= ' | execute "keepjumps normal! '.s:Apply(edit).'"'
     endfor
     execute l:cmd
-    execute 'update'
+    if !&hidden | execute 'update' | endif
     call lsc#file#onChange(l:file_path)
   endfor
 endfunction


### PR DESCRIPTION
When `nohidden` option is set, after apply edits, we have unsaved changes so we can't open other buffer to apply edits (E37).