### PR TITLE
Unlet callback before calling it to avoid recursion.

### DIFF
--- a/autoload/lsc/dispatch.vim
+++ b/autoload/lsc/dispatch.vim
@@ -46,8 +46,9 @@ function! lsc#dispatch#message(server, message) abort
   elseif has_key(a:message, 'result')
     let call_id = a:message['id']
     if has_key(s:callbacks, call_id)
-      call s:callbacks[call_id][0](a:message['result'])
+      let Callback = s:callbacks[call_id][0]
       unlet s:callbacks[call_id]
+      call Callback(a:message['result'])
     endif
   else
     echom 'Unknown message type: '.string(a:message)


### PR DESCRIPTION
Otherwise this is possible:
[lsc:Error] Error dispatching message: 'Vim(unlet):E716: Key not present in Dictionary: 2'