### PR TITLE
replace v:none with v:null since v:none is not supported in neovim

### DIFF
--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -60,7 +60,7 @@ function! lsc#config#mapKeys() abort
       \ 'WorkspaceSymbol',
       \ 'SignatureHelp',
       \] + (get(g:, 'lsc_enable_apply_edit', 1) ? ['Rename'] : [])
-    let lhs = get(l:maps, command, v:none)
+    let lhs = get(l:maps, command, v:null)
     if type(lhs) != v:t_string && type(lhs) != v:t_list
       continue
     endif


### PR DESCRIPTION
This should fix issue #147 which is throwing an error in neovim. It looks like `v:none` isn't used anywhere else in the codebase, but normally it's `v:null`. I've gone ahead and changed this in order to make neovim work, and I also played around with vim as well to make sure everything was acting as expected.