### PR TITLE
Trim a servers buffer before handling message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   and would be written to a directory that does not exist.
 - Add `:LSClientGoToDefinitionSplit` to go to definitions in a split window
   (depending on `switchbuf`).
+- Fix a race condition where the same message from the server may be handled
+  twice.
 
 # 0.3.1
 

--- a/autoload/lsc/protocol.vim
+++ b/autoload/lsc/protocol.vim
@@ -64,6 +64,8 @@ function! s:consumeMessage(server) abort
     return v:false
   endif
   let payload = message[message_start:message_end-1]
+  let remaining_message = message[message_end:]
+  let a:server.buffer = remaining_message
   try
     let content = json_decode(payload)
     if type(content) != v:t_dict | throw 1 | endif
@@ -81,8 +83,6 @@ function! s:consumeMessage(server) abort
       let g:lsc_last_error_message = content
     endtry
   endif
-  let remaining_message = message[message_end:]
-  let a:server.buffer = remaining_message
   return remaining_message != ''
 endfunction
 


### PR DESCRIPTION
This might prevent a case where we attempt to consume the same message
twice because the channel gives more data while another message is being
handled.