### PR TITLE
Support multiple contents on hover

### DIFF
--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -132,13 +132,17 @@ function! s:showHover(result) abort
     return
   endif
   let contents = a:result.contents
-  if type(contents) == v:t_list
-    let contents = contents[0]
+  if type(contents) != v:t_list
+    contents = [contents]
   endif
-  if type(contents) == v:t_dict
-    let contents = contents.value
-  endif
-  let lines = split(contents, "\n")
+  let lines = []
+  for item in contents
+    if type(item) == v:t_dict
+      let l:lines += split(item.value, "\n")
+    else
+      let l:lines += split(item, "\n")
+    endif
+  endfor
   call lsc#util#displayAsPreview(lines, function('lsc#util#noop'))
 endfunction
 


### PR DESCRIPTION
What
===
Display in the preview window all the contents items that are returned
by a language server on the hover command when multiple are returned.

Why
===
Some language servers return multiple contents. Often one will be a
code-block from the source that shows things like function parameter
names, etc, and then another will be the markdown from docs for the item
under the cursor.

At the moment only the first item is taken. In some language servers
multiple items are provided and vim-lsc is truncating the content by
only displaying the first.