### PR TITLE
Update curswant differently for goToDefinition

### DIFF
--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -108,14 +108,14 @@ function! s:goTo(file, line, character, mods, issplit) abort
   endif
   if prev_buf != bufnr('%')
     " switching buffers already left a jump
-    call cursor(a:line, a:character)
-    call getcurpos()  " updates curswant properly
+    " Set curswant manually to work around vim bug
+    call cursor([a:line, a:character, 0, virtcol([a:line, a:character])])
     redraw
   else
     " Move with 'G' to ensure a jump is left
     exec 'normal! '.a:line.'G'
-    call cursor(0, a:character)
-    call getcurpos()  " updates curswant properly
+    " Set curswant manually to work around vim bug
+    call cursor([0, a:character, 0, virtcol([a:line, a:character])])
   endif
 endfunction
 


### PR DESCRIPTION
vim removed the helpful bug I was using to set curswant for goToDefinition (https://github.com/vim/vim/issues/4069 / https://github.com/vim/vim/commit/19a66858a5e3fedadc371321834507c34e2dfb18).  So we need to set curswant manually instead.  Note that this is really a workaround for a different vim bug (https://github.com/vim/vim/issues/4074). That is, `call cursor(line, col)` should be doing this already, but doesn't inside job channel callbacks.
