### PR TITLE
Prevent empty name when attempt to rename

### DIFF
--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -81,6 +81,10 @@ function! lsc#edit#rename(...) abort
   else
     let new_name = input('Enter a new name: ')
   endif
+  if (empty(trim(new_name)))
+    echo 'Name can not be blank'
+    return
+  endif
   let params = lsc#params#documentPosition()
   let params.newName = new_name
   call lsc#server#userCall('textDocument/rename', params,

--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -82,7 +82,8 @@ function! lsc#edit#rename(...) abort
     let new_name = input('Enter a new name: ')
   endif
   if (empty(trim(new_name)))
-    echo 'Name can not be blank'
+    echo "\n"
+    call lsc#message#error('Name can not be blank')
     return
   endif
   let params = lsc#params#documentPosition()


### PR DESCRIPTION
Sometime I enter "rename mode" by mistake, or can't think of better
name, so I press <ESC> to cancel rename operation. But to my horror, all
references to that variable were deleted.