### PR TITLE
Allow :LSClientFindActions with visual selection

### DIFF
--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -5,7 +5,8 @@ function! lsc#edit#findCodeActions(...) abort
     let ActionFilter = function("<SID>ActionMenu")
   endif
   call lsc#file#flushChanges()
-  let params = lsc#params#documentRange()
+  let l:usingRange = a:0 > 2 && (a:2 != 1 || a:3 != line('$'))
+  let params = lsc#params#documentRange(l:usingRange)
   let params.context = {'diagnostics':
       \ lsc#diagnostics#forLine(lsc#file#fullPath(), line('.'))}
   call lsc#server#userCall('textDocument/codeAction', params,

--- a/autoload/lsc/params.vim
+++ b/autoload/lsc/params.vim
@@ -8,10 +8,16 @@ function! lsc#params#documentPosition() abort
       \ }
 endfunction
 
-function! lsc#params#documentRange() abort
+function! lsc#params#documentRange(usingRange) abort
+  let l:mode = mode()
+  let l:start = a:usingRange ? getpos("'<") : getpos('.')
+  let l:end = a:usingRange ? getpos("'>") : getpos('.')
+  " Fallback if range marks didn't exist
+  let l:start = l:start[1] == 0 ? getpos('.') : l:start
+  let l:end = l:end[1] == 0 ? getpos('.') : l:end
   return { 'textDocument': {'uri': lsc#uri#documentUri()},
       \ 'range': {
-      \   'start': {'line': line('.') - 1, 'character': col('.') - 1},
-      \   'end': {'line': line('.') - 1, 'character': col('.')}},
+      \   'start': {'line': l:start[1] - 1, 'character': l:start[2] - 1},
+      \   'end': {'line': l:end[1] - 1, 'character': l:end[2]}},
       \ }
 endfunction

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -29,8 +29,9 @@ command! -nargs=? LSClientShowHover call lsc#reference#hover()
 command! LSClientDocumentSymbol call lsc#reference#documentSymbols()
 command! -nargs=? LSClientWorkspaceSymbol
     \ call lsc#search#workspaceSymbol(<args>)
-command! -nargs=? LSClientFindCodeActions
-    \ call lsc#edit#findCodeActions(lsc#edit#filterActions(<args>))
+command! -nargs=? -range=% LSClientFindCodeActions
+    \ call lsc#edit#findCodeActions(
+    \   lsc#edit#filterActions(<args>), <line1>, <line2>)
 command! LSClientAllDiagnostics call lsc#diagnostics#showInQuickFix()
 command! LSClientLineDiagnostics call lsc#diagnostics#echoForLine()
 command! LSClientSignatureHelp call lsc#signaturehelp#getSignatureHelp()


### PR DESCRIPTION
Towards #178

Uses a hack to try to figure out if the user is likely to have set
reasonable marks for the range and is running from a visual selection so
that lines were passed with `:'<,'>LSClientFindCodeActions`.