### PR TITLE
Fix the response path for messages

### DIFF
--- a/autoload/lsc/protocol.vim
+++ b/autoload/lsc/protocol.vim
@@ -108,7 +108,8 @@ function! s:Dispatch(message, OnMessage, callbacks) abort
   if has_key(a:message, 'method')
     let l:method = a:message.method
     let l:params = has_key(a:message, 'params') ? a:message.params : v:null
-    call a:OnMessage(l:method, l:params)
+    let l:id = has_key(a:message, 'id') ? a:message.id : v:null
+    call a:OnMessage(l:method, l:params, l:id)
   elseif has_key(a:message, 'error')
     let l:error = a:message.error
     let l:message = has_key(l:error, 'message') ?

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -247,7 +247,7 @@ function! lsc#server#register(filetype, config) abort
     return v:true
   endfunction
   function server.respond(id, result) abort
-    call self._channel.respond(a:it, a:result)
+    call self._channel.respond(a:id, a:result)
   endfunction
   function server._initialize(params, callback) abort
     let l:params = lsc#config#messageHook(self, 'initialize', a:params)

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -314,7 +314,6 @@ function! s:Dispatch(server, method, params, id) abort
     let l:applied = lsc#edit#apply(a:params.edit)
     let l:response = {'applied': l:applied}
     call a:server.respond(a:id, l:response)
-    endif
   elseif a:method =~? '\v^\$'
     call lsc#config#handleNotification(a:server, a:method, a:params)
   else

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -246,8 +246,8 @@ function! lsc#server#register(filetype, config) abort
     call self._channel.notify(a:method, l:params)
     return v:true
   endfunction
-  function server.respond(method, params) abort
-    call self._channel.respond(a:method, a:params)
+  function server.respond(id, result) abort
+    call self._channel.respond(a:it, a:result)
   endfunction
   function server._initialize(params, callback) abort
     let l:params = lsc#config#messageHook(self, 'initialize', a:params)
@@ -285,7 +285,7 @@ function! lsc#server#register(filetype, config) abort
   let s:servers[config.name] = server
 endfunction
 
-function! s:Dispatch(server, method, params) abort
+function! s:Dispatch(server, method, params, id) abort
   if a:method ==? 'textDocument/publishDiagnostics'
     let file_path = lsc#uri#documentPath(a:params['uri'])
     call lsc#diagnostics#setForFile(file_path, a:params['diagnostics'])
@@ -294,10 +294,7 @@ function! s:Dispatch(server, method, params) abort
   elseif a:method ==? 'window/showMessageRequest'
     let l:response =
         \ lsc#message#showRequest(a:params['message'], a:params['actions'])
-    if has_key(a:params['message'], 'id')
-      let l:id = a:params['message']['id']
-      call a:server.reply(id, response)
-    endif
+    call a:server.respond(a:id, l:response)
   elseif a:method ==? 'window/logMessage'
     if lsc#config#shouldEcho(a:server, a:params.type)
       call lsc#message#log(a:params.message, a:params.type)
@@ -314,11 +311,9 @@ function! s:Dispatch(server, method, params) abort
       call lsc#message#show('Starting ' . a:params['title'])
     endif
   elseif a:method ==? 'workspace/applyEdit'
-    let applied = lsc#edit#apply(a:params.edit)
-    if has_key(a:params, 'message') && has_key(a:params['message'], 'id')
-      let l:id = a:params['message']['id']
-      let l:response = {'applied': applied}
-      call a:server.reply(l:id, l:response)
+    let l:applied = lsc#edit#apply(a:params.edit)
+    let l:response = {'applied': l:applied}
+    call a:server.respond(a:id, l:response)
     endif
   elseif a:method =~? '\v^\$'
     call lsc#config#handleNotification(a:server, a:method, a:params)


### PR DESCRIPTION
Fixes #188

This fixes a bug introduced in b0b0631474a5dbd5c102ce90c591070fccb02620
where the `params` was treated as if it was the entire message instead
of the parameters value.