### PR TITLE
make flushing on change configurable

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -40,8 +40,10 @@ function! lsc#file#onClose(full_path, filetype) abort
   endif
 endfunction
 
-" Send a `textDocument/didSave` notification if the server may be interested.
+" Flush changes and send a `textDocument/didSave` notification if the server
+" may be interested.
 function! lsc#file#onWrite(full_path, filetype) abort
+  call s:FlushChanges(a:full_path, a:filetype)
   let l:params = {'textDocument': {'uri': lsc#uri#documentUri(a:full_path)}}
   for l:server in lsc#server#forFileType(a:filetype)
     if !l:server.capabilities.textDocumentSync.sendDidSave | continue | endif
@@ -96,6 +98,7 @@ function! lsc#file#clean(filetype) abort
 endfunction
 
 function! lsc#file#onChange(...) abort
+  if !g:lsc_flush_on_change | return | endif
   if a:0 >= 1
     let file_path = a:1
     let filetype = getbufvar(lsc#file#bufnr(file_path), '&filetype')

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -266,6 +266,13 @@ with "g:lsc_preview_split_direction" set to either |above| or |below|. This
 configuration will not impact the preview window which may open during
 completion.
 
+                                                *lsc-configure-flush-on-change*
+                                                *g:lsc_flush_on_change*
+By default all changes to a buffer are flushed to the server and diagnostics
+are updated as soon as you stop typing. You can disable this behaviour by
+setting `g:lsc_flush_on_change` to `v:false`. With `g:lsc_flush_on_change`
+disabled, diagnostics are only updated when you save the file.
+
                                                 *lsc-configure-highlight*
 vim-lsc uses highlight groups "lscDiagnosticError", "lscDiagnosticWarning",
 "lscDiagnosticInfo", "lscDiagnosticHint", "lscReference", and

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -16,6 +16,9 @@ endif
 if !exists('g:lsc_enable_snippet_support')
   let g:lsc_enable_snippet_support = v:false
 endif
+if !exists('g:lsc_flush_on_change')
+  let g:lsc_flush_on_change = v:true
+endif
 
 command! LSClientGoToDefinitionSplit
     \ call lsc#reference#goToDefinition(<q-mods>, 1)


### PR DESCRIPTION
* adds `g:lsc_flush_on_change` (defaults to true)
* always flush buffer on write

i.e. if you set g:lsc_flush_on_change to `v:false`, the diagnostics will only be updated when you save.