### PR TITLE
Remove b:lsc_completion when empty

### DIFF
--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -163,7 +163,10 @@ function! lsc#complete#complete(findstart, base) abort
     endif
   endif
   if a:findstart
-    if len(b:lsc_completion.items) == 0 | return -3 | endif
+    if len(b:lsc_completion.items) == 0
+      unlet b:lsc_completion
+      return -3
+    endif
     return  s:FindStart(b:lsc_completion) - 1
   else
     return s:FindSuggestions(a:base, b:lsc_completion)


### PR DESCRIPTION
Fixes #184

Returning `-3` when invoked for `a:findstart` is supposed to also leave
completion mode, which should fire the `CompleteDone` autocmd but that
may not always be happening. Handle clearing `b:lsc_completion` eagerly
in this case to handle situations where the autocmd does not fire.