### PR TITLE
Add support for `workspace_config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - After calling `:LSClientAllDiagnostics` the quickfix list will be kept up to
   date with all diagnostics across the project, until it is set by some other
   tool.
+- Add support for a `workspace_config` server configuration key which causes a
+  `workspace/didChangeConfiguration` notification on server startup.
 
 # 0.3.2
 

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -16,6 +16,8 @@ if !exists('s:initialized')
   "   - command: Executable
   "   - enabled: (optional) Whether the server should be started.
   "   - message_hooks: (optional) Functions call to override params
+  "   - workspace_config: (optional) Arbitrary data to send as
+  "     `workspace/didChangeConfiguration` settings on startup.
   let s:servers = {}
   let s:initialized = v:true
 endif
@@ -125,6 +127,11 @@ function! s:Start(server) abort
     if type(a:init_result) == type({}) && has_key(a:init_result, 'capabilities')
       let a:server.capabilities =
           \ lsc#capabilities#normalize(a:init_result.capabilities)
+    endif
+    if has_key(a:server.config, 'workspace_config')
+      call a:server.notify('workspace/didChangeConfiguration', {
+          \ 'settings': a:server.config.workspace_config
+          \})
     endif
     for filetype in a:server.filetypes
       call lsc#file#trackAll(filetype)

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -481,6 +481,24 @@ For example:
 
 <
 
+                                                *lsc-server-workspace_config*
+`workspace_config`: Set to any json encodable value which will be sent to the
+server after startup as the `settings` in a `workspace/didChangeConfiguration`
+notificaiton. See the documentation for your server for what values are accepted
+in this notification.
+
+For example:
+>
+ let g:lsc_server_commands = {
+     \ 'rust': {
+     \    'command': 'rls',
+     \    'workspace_config': {
+     \        'clippy_preference': 'on',
+     \    },
+     \  },
+     \}
+<
+
 DEBUGGING TIPS                                  *lsc-debugging*
 
 If you are having difficulty with integration with a particular language


### PR DESCRIPTION
Fixes #182

If a `workspace_config` is provided for a server, send a
`workspace/didChangeConfiguration` notification on startup with it's
value as the `settings`.