### PR TITLE
Fix completion at beginning of the line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Avoid sending unnecessary `didClose` notifications for buffers of the wrong
   filetype.
 - Fix `getbufinfo` calls for loaded buffers.
+- Fix completions starting at the beginning of the line when the server did not
+  send any items containing a `textEdit` field.
 
 **Minor breaking changes**
 - Server dictionaries no longer expose their full `init_results`, or their call

--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -173,6 +173,7 @@ function! lsc#complete#complete(findstart, base) abort
   endif
 endfunction
 
+" Finds the 1-based index of the first character in the completion.
 function! s:FindStart(completion) abort
   if has_key(a:completion, 'start_col')
     return a:completion.start_col
@@ -180,7 +181,8 @@ function! s:FindStart(completion) abort
   return s:GuessCompletionStart()
 endfunction
 
-" Finds the character after the last non word character behind the cursor.
+" Finds the 1-based index of the character after the last non word character
+" behind the cursor.
 function! s:GuessCompletionStart()
   let search = col('.') - 2
   let line = getline('.')
@@ -191,8 +193,7 @@ function! s:GuessCompletionStart()
     endif
     let search -= 1
   endwhile
-  " TODO: ??? completion at the beginning of the line?
-  return 0
+  return 1
 endfunction
 
 function! s:FindSuggestions(base, completion) abort


### PR DESCRIPTION
Fixes #183

If none of the completion items had a `textEdit` to find a server
specified start character a heuristic using vim's notion of word
characters is used - in the case of no non-word characters until the
beginning of the line this had a bug which made manual completion use
the cursor position instead.

Add some comments about using 1-based character indexes returned. We use
0-based for `completefunc` use cases, but 1 based for calls to
`complete()`.