### PR TITLE
Give 1 extra character for message truncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `getbufinfo` calls for loaded buffers.
 - Fix completions starting at the beginning of the line when the server did not
   send any items containing a `textEdit` field.
+- Truncate diagnostics at 1 character shorter for when `ruler` is used.
 
 **Minor breaking changes**
 - Server dictionaries no longer expose their full `init_results`, or their call

--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -24,9 +24,11 @@ endfunction
 function! lsc#cursor#showDiagnostic() abort
   let l:diagnostic = lsc#diagnostics#underCursor()
   if has_key(l:diagnostic, 'message')
-    let l:max_width = &columns - 18
+    let l:max_width = &columns
+    let l:max_width -= 19 " Default ruler width (18) plus 1 character buffer
     let l:message = strtrans(l:diagnostic.message)
     if strdisplaywidth(l:message) > l:max_width
+      let l:max_width -= 3 " 3 chars for '...'
       let l:truncated = strcharpart(l:message, 0, l:max_width)
       " Trim by character until a satisfactory display width.
       while strdisplaywidth(l:truncated) > l:max_width


### PR DESCRIPTION
The ruler takes up 18 characters and we need 1 extra character in
between. Also fix the width for the truncate case since we need room for
the `'...'`.

Potential future enhancement - check if ruler is used and potentially
the width of a custom ruler format.