### PR TITLE
Fix error when move cursor to end of file

### DIFF
--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -278,6 +278,7 @@ function! lsc#diagnostics#underCursor() abort
         return l:file_diagnostics[l:diagnostic_line][0]
       endif
     endfor
+    return {}
   endif
   let diagnostics = l:file_diagnostics[l:line]
   let col = col('.')


### PR DESCRIPTION
If there are no diagnostics information at the end of file or any line
after it the code out side of if statement would be executed causing
error