### PR TITLE
Make diagnostic conversion more lazy

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -205,3 +205,13 @@ function! lsc#file#normalize(buffer_name) abort
   let s:normalized_paths[l:full_path] = a:buffer_name
   return l:full_path
 endfunction
+
+function! lsc#file#compare(file_1, file_2) abort
+  if a:file_1 == a:file_2 | return 0 | endif
+  let l:cwd = '^'.getcwd()
+  let l:file_1_in_cwd = a:file_1 =~# l:cwd
+  let l:file_2_in_cwd = a:file_2 =~# l:cwd
+  if l:file_1_in_cwd && !l:file_2_in_cwd | return -1 | endif
+  if l:file_2_in_cwd && !l:file_1_in_cwd | return 1 | endif
+  return a:file_1 > a:file_2 ? 1 : -1
+endfunction

--- a/autoload/lsc/highlights.vim
+++ b/autoload/lsc/highlights.vim
@@ -14,21 +14,19 @@ function! lsc#highlights#update() abort
   if s:CurrentWindowIsFresh() | return | endif
   call lsc#highlights#clear()
   if &diff | return | endif
-  for line in values(lsc#diagnostics#forFile(lsc#file#fullPath()))
-    for diagnostic in line
-      if l:diagnostic.ranges[0][0] > line('$')
-        " Diagnostic starts after end of file
-        let l:match = matchadd(diagnostic.group, '\%'.line('$').'l$')
-      elseif len(l:diagnostic.ranges) == 1 &&
-          \ l:diagnostic.ranges[0][1] > len(getline(l:diagnostic.ranges[0][0]))
-        " Diagnostic starts after end of line
-        let l:match =
-            \ matchadd(diagnostic.group, '\%'.l:diagnostic.ranges[0][0].'l$')
-      else
-        let l:match = matchaddpos(diagnostic.group, diagnostic.ranges, -1)
-      endif
-      call add(w:lsc_diagnostic_matches, l:match)
-    endfor
+  for l:highlight in lsc#diagnostics#forFile(lsc#file#fullPath()).Highlights()
+    if l:highlight.ranges[0][0] > line('$')
+      " Diagnostic starts after end of file
+      let l:match = matchadd(l:highlight.group, '\%'.line('$').'l$')
+    elseif len(l:highlight.ranges) == 1 &&
+        \ l:highlight.ranges[0][1] > len(getline(l:highlight.ranges[0][0]))
+      " Diagnostic starts after end of line
+      let l:match =
+          \ matchadd(l:highlight.group, '\%'.l:highlight.ranges[0][0].'l$')
+    else
+      let l:match = matchaddpos(l:highlight.group, l:highlight.ranges, -1)
+    endif
+    call add(w:lsc_diagnostic_matches, l:match)
   endfor
   call s:MarkCurrentWindowFresh()
 endfunction

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -49,11 +49,7 @@ function! lsc#util#compareQuickFixItems(i1, i2) abort
   let file_1 = s:QuickFixFilename(a:i1)
   let file_2 = s:QuickFixFilename(a:i2)
   if file_1 != file_2
-    let l:file_1_in_cwd = s:IsInCwd(l:file_1)
-    let l:file_2_in_cwd = s:IsInCwd(l:file_2)
-    if l:file_1_in_cwd && !l:file_2_in_cwd | return -1 | endif
-    if l:file_2_in_cwd && !l:file_1_in_cwd | return 1 | endif
-    return file_1 > file_2 ? 1 : -1
+    return lsc#file#compare(l:file_1, l:file_2)
   endif
   if a:i1.lnum != a:i2.lnum | return a:i1.lnum - a:i2.lnum | endif
   if a:i1.col != a:i2.col | return a:i1.col - a:i2.col | endif
@@ -77,11 +73,7 @@ function! s:QuickFixFilename(item) abort
   if has_key(a:item, 'filename')
     return a:item.filename
   endif
-  return bufname(a:item.bufnr)
-endfunction
-
-function! s:IsInCwd(file_path) abort
-  return a:file_path =~# '^'.getcwd()
+  return lsc#file#normalize(bufname(a:item.bufnr))
 endfunction
 
 " Populate a buffer with [lines] and show it as a preview window.


### PR DESCRIPTION
When opening a file in a project with many errors the editor can freeze
up, due mostly to an egregious amount of unnecessary sorting. By making
most of the format and conversion lazy the editor is more responsive,
though there is still a bit of roughness due to json decoding which
can't be avoided.

- Make the file diagnostics a dict with methods that can lazily format
  into the more usable views. These are all memoized back onto the dict
  in separate fields.
  - `Highlights()` - the ranges and levels for diagnostic highlights.
    No sorting needed. This is the only field which maintains the same
    `ranges` format which was only useful for highlights but was
    shoehorned in for everything else.
  - `ListItems()` - Items in quick fix or location list format. Sorted.
  - `ByLine()` - Diagnostic lists by the line the start on. Each line
    has diagnostics sorted by diagnostic start point to make it easier
    to find the 'nearest' to the cursor. The range here is in the LSP
    format.
- Add an `s:EmptyDiagnostics()` which reused the same instance and
  always returns empty lists or dicts for each method.
- Add a utility `lsc#file#compare` to order file paths. This is the same
  logic that used to be used when sorting quick fix items but now can be
  used independently.
- Only add the first 500 (or so) diagnostics in
  `LSClientAllDiagnostics`. This helps prevent the editor for freezing
  up when there are lots. Sort first by file path so that a more
  consistent set of diagnostics is used as more are coming in. Since
  we're sorting by file path and then individual files already have
  their `ListItems()` sorted we don't need a duplicate sort for all of
  the diagnostics.
- Change the closest diagnostic search to have an explicit notion of the
  diagnostics which contain the cursor so that they can be preferred,
  update to use the LSP range format.
- Change `lsc#diagnostics#forLine` to return all diagnostics which span
  the line at all, not only those which start on that line. Use the
  original list from the server instead of the dict that breaks them
  down by line.
- Normalize file paths when checking for which are in cwd for sorting
  quick fix items for consistency with the sort in
  `LSClientAllDiagnostics` which uses full paths.