### PR TITLE
Fix closure usage in server

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -60,7 +60,7 @@ function! lsc#server#exit() abort
     let l:pending -= 1
   endfunction
   for l:server in values(s:servers)
-    if s:Kill(l:server, 'exiting', function('OnExit'))
+    if s:Kill(l:server, 'exiting', funcref('OnExit'))
       let l:pending += 1
     endif
   endfor
@@ -84,7 +84,7 @@ function! s:Kill(server, status, OnExit) abort
     endif
     if a:OnExit != v:null | call a:OnExit() | endif
   endfunction
-  return a:server.request('shutdown', v:null, function('Exit'))
+  return a:server.request('shutdown', v:null, funcref('Exit'))
 endfunction
 
 function! lsc#server#restart() abort
@@ -152,7 +152,7 @@ function! s:Start(server) abort
       \ 'capabilities': s:ClientCapabilities(),
       \ 'trace': trace_level
       \}
-  call a:server._initialize(l:params, function('OnInitialize'))
+  call a:server._initialize(l:params, funcref('OnInitialize'))
 endfunction
 
 " Missing value means no support


### PR DESCRIPTION
Use funcref() instead of function() so that the captured values are fully preserved.

Example: replacing `funcref` with `function` in the following snippet will result in `30` being printed 3 times instead of `10`, `20`, `30`.

``` vim
function! Foo(foo)
    function! Bar() closure abort
        echo a:foo
    endfunction
    return funcref('Bar')
endfunction

let g:TestF = []
for i in ['10', '20', '30']
    call add(g:TestF, Foo(i))
endfor

for TestFf in g:TestF
    call TestFf()
endfor
````

Disclaimer: this is the longest vimscript program I've ever written.