### PR TITLE
fix #216

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -202,7 +202,7 @@ endfunction
 
 " If `buffer_name` is relative, normalize it against `cwd`.
 function! lsc#file#normalize(buffer_name) abort
-  if a:buffer_name[0] ==# '/' | return a:buffer_name | endif
+  if a:buffer_name =~ '^/\|\%([c-zC-Z]:[/\\]\)' | return a:buffer_name | endif
   let l:full_path = getcwd().'/'.a:buffer_name
   let s:normalized_paths[l:full_path] = a:buffer_name
   return l:full_path


### PR DESCRIPTION
lsc#file#normalize should consider windows full paths on
relative/non-relative path checks.