### PR TITLE
Add travis config for vint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - python3-pip
 
 before_install:
-  - pip3 install --user vim-vint
+  - pip3 install --user setuptools vim-vint
 
 script:
   - vint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+addons:
+  apt:
+    update: true
+    packages:
+      - python3
+      - python3-pip
+
+before_install:
+  - pip3 install --user vim-vint
+
+script:
+  - vint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ addons:
     packages:
       - python3
       - python3-pip
+      - python3-setuptools
 
 before_install:
-  - pip3 install --user setuptools vim-vint
+  - pip3 install --user vim-vint
 
 script:
   - vint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 addons:
   apt:
     update: true

--- a/.vintrc.yml
+++ b/.vintrc.yml
@@ -1,0 +1,5 @@
+cmdargs:
+  severity: style_problem
+  color: true
+  env:
+    neovim: true

--- a/.vintrc.yml
+++ b/.vintrc.yml
@@ -1,5 +1,3 @@
 cmdargs:
   severity: style_problem
   color: true
-  env:
-    neovim: true

--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -202,7 +202,7 @@ endfunction
 
 " If `buffer_name` is relative, normalize it against `cwd`.
 function! lsc#file#normalize(buffer_name) abort
-  if a:buffer_name =~ '^/\|\%([c-zC-Z]:[/\\]\)' | return a:buffer_name | endif
+  if a:buffer_name =~# '^/\|\%([c-zC-Z]:[/\\]\)' | return a:buffer_name | endif
   let l:full_path = getcwd().'/'.a:buffer_name
   let s:normalized_paths[l:full_path] = a:buffer_name
   return l:full_path

--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -154,13 +154,13 @@ function! s:showHover(result) abort
   endif
 endfunction
 
-function! s:openHoverPopup(lines)
+function! s:openHoverPopup(lines) abort
   " Sanity check, if there is no hover text then don't waste resources creating an
   " empty popup.
   if len(a:lines) == 0
     return
   endif
-  if has("nvim")
+  if has('nvim')
     let buf = nvim_create_buf(v:false, v:true)
     " Note, the +2s below will be used for padding around the hover text.
     let height = len(a:lines) + 2
@@ -186,7 +186,7 @@ function! s:openHoverPopup(lines)
     call map(a:lines, {_, val -> ' ' . val . ' '})
     call nvim_buf_set_lines(winbufnr(s:popup_id), 1, -1, v:false, a:lines)
     " Close the floating window upon a cursor move.
-    autocmd CursorMoved <buffer> ++once call s:closeHoverPopup()
+    autocmd LSCPopup CursorMoved <buffer> ++once call s:closeHoverPopup()
   else
     let s:popup_id = popup_atcursor(a:lines, {
           \ 'padding': [1, 1, 1, 1],
@@ -196,8 +196,8 @@ function! s:openHoverPopup(lines)
   end
 endfunction
 
-function! s:closeHoverPopup()
-  if has("nvim")
+function! s:closeHoverPopup() abort
+  if has('nvim')
     if win_id2win(s:popup_id) > 0 && nvim_win_is_valid(s:popup_id)
       call nvim_win_close(s:popup_id, v:true)
     endif

--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -186,7 +186,10 @@ function! s:openHoverPopup(lines) abort
     call map(a:lines, {_, val -> ' ' . val . ' '})
     call nvim_buf_set_lines(winbufnr(s:popup_id), 1, -1, v:false, a:lines)
     " Close the floating window upon a cursor move.
-    autocmd LSCPopup CursorMoved <buffer> ++once call s:closeHoverPopup()
+    " vint: -ProhibitAutocmdWithNoGroup
+    " https://github.com/Kuniwak/vint/issues/285
+    autocmd CursorMoved <buffer> ++once call s:closeHoverPopup()
+    " vint: +ProhibitAutocmdWithNoGroup
   else
     let s:popup_id = popup_atcursor(a:lines, {
           \ 'padding': [1, 1, 1, 1],


### PR DESCRIPTION
- Add config to install and run `vint` on travis.
- Add vint config for stricter checking and color output.
- Fix most lints.
- Ignore a lint around using an augroup along with `++once` in an autocmd.