### PR TITLE
Add support for modifying server responses

### DIFF
--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -87,6 +87,16 @@ function! lsc#config#mapKeys() abort
   endif
 endfunction
 
+" Wraps [Callback] with a function that will first translate a result through a
+" user provided translation.
+function! lsc#config#responseHook(server, method, Callback) abort
+  if !has_key(a:server.config, 'response_hooks') | return a:Callback | endif
+  let l:hooks = a:server.config.response_hooks
+  if !has_key(l:hooks, a:method) | return a:Callback | endif
+  let l:Hook = l:hooks[a:method]
+  return {result -> a:Callback(l:Hook(result))}
+endfunction
+
 function! lsc#config#messageHook(server, method, params) abort
   if !has_key(a:server.config, 'message_hooks') | return a:params | endif
   let hooks = a:server.config.message_hooks

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -247,7 +247,8 @@ function! lsc#server#register(filetype, config) abort
     if self.status !=# 'running' | return v:false | endif
     let l:params = lsc#config#messageHook(self, a:method, a:params)
     if l:params is lsc#config#skip() | return v:false | endif
-    call self._channel.request(a:method, l:params, a:callback)
+    let l:Callback = lsc#config#responseHook(self, a:method, a:callback)
+    call self._channel.request(a:method, l:params, l:Callback)
     return v:true
   endfunction
   function! server.notify(method, params) abort

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -460,6 +460,41 @@ For example:
      \  },
      \}
 <
+                                                *lsc-server-response_hooks*
+`'response_hooks'`: Set to a dictionary where the keys are LSP method names and
+the values are |funcref|s which may modify the response to a call. The
+modified or new response should be returned by the function. This can be used
+if a server sends a response in a way that is not compatible with this client,
+but the response can be translated into a compatible version.
+
+For example:
+>
+ let g:lsc_server_commands = {
+     \ 'java': {
+     \    'command': 'run_java_server.sh',
+     \    'response_hooks': {
+     \        'textDocument/codeAction': function('<SID>fixEdits'),
+     \    },
+     \  },
+     \}
+
+ " Turn the invalid java.apply.workspaceEdit commands into an edit
+ " action which complies with the LSP spec
+ function! s:fixEdits(actions) abort
+   return map(a:actions, function('<SID>fixEdit'))
+ endfunction
+
+ function! s:fixEdit(idx, maybeEdit) abort
+   if !has_key(a:maybeEdit, 'command') ||
+       \ !has_key(a:maybEdit.command, 'command') ||
+       \ a:maybeEdit.command.command !=# 'java.apply.workspaceEdit'
+         return a:maybeEdit
+   endif
+   return {
+       \ 'edit': a:maybeEdit.command.arguments[0],
+       \ 'title': a:maybeEdit.command.title}
+ endfunction
+<
                                                 *lsc-server-notifications*
 `notifications`: Set to a dictionary where the keys are LSP notification
 methods and the values are |funcref|s to be invoked when those notifications


### PR DESCRIPTION
Workaround for #88

Add a `'response_hooks'` config key which can intercept responses and do
some modification before continuing to the response handler.

Needs docs.