### PR TITLE
Add an LSCDiagnosticsChange autocmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - Add support for a `workspace_config` server configuration key which causes a
   `workspace/didChangeConfiguration` notification on server startup.
 - Use the popup window for hover.
+- Add autocmd `User LSCDiagnosticsChange` to trigger when diagnostics are
+  received.
 
 # 0.3.2
 

--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -78,11 +78,6 @@ function! lsc#diagnostics#setForFile(file_path, diagnostics) abort
   if empty(a:diagnostics) && !has_key(s:file_diagnostics, a:file_path)
     return
   endif
-  if has_key(s:diagnostic_versions, a:file_path)
-    let s:diagnostic_versions[a:file_path] += 1
-  else
-    let s:diagnostic_versions[a:file_path] = 1
-  endif
   if !empty(a:diagnostics)
     if has_key(s:file_diagnostics, a:file_path) &&
         \ s:file_diagnostics[a:file_path].lsp_diagnostics == a:diagnostics
@@ -93,9 +88,17 @@ function! lsc#diagnostics#setForFile(file_path, diagnostics) abort
   else
     unlet s:file_diagnostics[a:file_path]
   endif
+  if has_key(s:diagnostic_versions, a:file_path)
+    let s:diagnostic_versions[a:file_path] += 1
+  else
+    let s:diagnostic_versions[a:file_path] = 1
+  endif
   call lsc#diagnostics#updateLocationList(a:file_path)
   call lsc#highlights#updateDisplayed()
   call s:UpdateQuickFix()
+  if exists('#User#LSCDiagnosticsChange')
+    doautocmd <nomodeline> User LSCDiagnosticsChange
+  endif
   if(a:file_path ==# lsc#file#fullPath())
     call lsc#cursor#showDiagnostic()
   endif

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -387,6 +387,10 @@ below:
    autocmd CompleteDone * setlocal nosplitbelow
  augroup END
 <
+                                                *autocmd-LSCDiagnosticsChange*
+Fires when LSC receives new diagnostics for any file in the workspace. Never
+fires if |g:lsc_enable_diagnostics| is set to `v:false`.
+
                                                 *autocmd-LSCShowPreview*
 Fires when LSC opens a new preview window during `:LSClientShowHover` or
 `LSClientSignatureHelp`. Does not fire if an exist preview window was reused.


### PR DESCRIPTION
Closes #227

Move the update to `diagnostic_versions` to after the bail out for
identical diagnostics. This puts it in the same block as the rest of the
reactions to diagnostics changing.

Trigger the autocmd `User LSCDiagnosticsChange` after storing the
updated diagnostics and handling highlights and location lists.