### PR TITLE
Split SelectAction function

### DIFF
--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -19,15 +19,19 @@ function! s:SelectAction(result, action_filter) abort
     return
   endif
   let l:choice = a:action_filter(a:result)
-  if type(l:choice) == type({})
-    if has_key(l:choice, 'command') && type(l:choice.command) == type('')
-      call s:ExecuteCommand(l:choice)
+  call lsc#edit#applyCodeAction(l:choice)
+endfunction
+
+function! lsc#edit#applyCodeAction(action) abort
+  if type(a:action) == type({})
+    if has_key(a:action, 'command') && type(a:action.command) == type('')
+      call s:ExecuteCommand(a:action)
     else
-      if has_key(l:choice, 'edit') && type(l:choice.edit) == type({})
-        call lsc#edit#apply(l:choice.edit)
+      if has_key(a:action, 'edit') && type(a:action.edit) == type({})
+        call lsc#edit#apply(a:action.edit)
       endif
-      if has_key(l:choice, 'command') && type(l:choice.command) == type({})
-        call s:ExecuteCommand(l:choice.command)
+      if has_key(a:action, 'command') && type(a:action.command) == type({})
+        call s:ExecuteCommand(a:action.command)
       endif
     endif
   endif


### PR DESCRIPTION
Hi,

I wanted to use FZF to select among the code actions. I was able to do so without any LSC changes by using:

```
" use FZF for code actions
function! s:FZFCodeActionSource(actions) abort
    return map(deepcopy(a:actions), 'v:val.title')
endfunction

function! s:FZFCodeActionSink(actions, selected) abort
    for action in a:actions
        if a:selected == action.title
            let l:choice = action
            if type(l:choice) == type({})
                if has_key(l:choice, 'command') && type(l:choice.command) == type('')
                call s:ExecuteCommand(l:choice)
                else
                if has_key(l:choice, 'edit') && type(l:choice.edit) == type({})
                    call lsc#edit#apply(l:choice.edit)
                endif
                if has_key(l:choice, 'command') && type(l:choice.command) == type({})
                    call s:ExecuteCommand(l:choice.command)
                endif
                endif
            endif
        endif
    endfor
endfunction

function! s:ExecuteCommand(command) abort
  call lsc#server#userCall('workspace/executeCommand',
      \ {'command': a:command.command,
      \ 'arguments': a:command.arguments},
      \ {_->0})
endfunction

function! s:FZFSelectAction(actions) abort
    call fzf#run(fzf#wrap({
        \ 'source': s:FZFCodeActionSource(a:actions),
        \ 'sink': function('<SID>FZFCodeActionSink', [a:actions]),
        \ 'down': '~40%',
        \ 'options': '+m',
        \ }))
    return v:true
endfunction

nnoremap ga :call lsc#edit#findCodeActions(function('<SID>FZFSelectAction'))<Return>
```

However, as you can see, Im reusing your `s:ExecuteCommand(command)` function and most of `s:SelectAction(result, action_filter)`

This PR just splits `s:SelectAction(result, action_filter)` to expose the apply code action part as `lsc#edit#applyCodeAction(action)`. This way, I dont need to use LSC code in my config and the following config brings fuzy selection for code actions:

```
" use FZF for code actions
function! s:FZFCodeActionSource(actions) abort
    return map(deepcopy(a:actions), 'v:val.title')
endfunction

function! s:FZFCodeActionSink(actions, selected) abort
    for action in a:actions
        if a:selected == action.title
            call lsc#edit#applyCodeAction(action)
            break
        endif
    endfor
endfunction

function! s:FZFSelectAction(actions) abort
    call fzf#run(fzf#wrap({
        \ 'source': s:FZFCodeActionSource(a:actions),
        \ 'sink': function('<SID>FZFCodeActionSink', [a:actions]),
        \ 'down': '~40%',
        \ 'options': '+m',
        \ }))
    return v:true
endfunction

nnoremap ga :call lsc#edit#findCodeActions(function('<SID>FZFSelectAction'))<Return>
```