### PR TITLE
New prefix match completions option #226

### DIFF
--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -199,10 +199,20 @@ endfunction
 function! s:FindSuggestions(base, completion) abort
   let items = copy(a:completion.items)
   if len(a:base) == 0 | return items | endif
-  return filter(items, {_, item -> s:MatchSuggestion(a:base, item)})
+  if exists('g:lsc_prefix_match_completions') && g:lsc_prefix_match_completions
+      return filter(items, {_, item -> s:MatchSuggestionByPrefix(a:base, item)})
+  else
+      return filter(items, {_, item -> s:MatchSuggestionBySubstr(a:base, item)})
+  endif
 endfunction
 
-function! s:MatchSuggestion(base, suggestion) abort
+function! s:MatchSuggestionByPrefix(base, suggestion) abort
+  let word = a:suggestion
+  if type(word) == type({}) | let word = word.word | endif
+  return match(word, '\C' . a:base) == 0
+endfunction
+
+function! s:MatchSuggestionBySubstr(base, suggestion) abort
   let word = a:suggestion
   if type(word) == type({}) | let word = word.word | endif
   return word =~? a:base

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -383,6 +383,12 @@ a `title` field) and the callback to invoke an action after it is chosen. If no
 action should be run, skip the call to the passed callback. This may be used,
 for example, to add in fuzzy finding of actions instead of a numbered selection.
 
+                                                *lsc-configure-complete-match*
+                                                *g:lsc_prefix_match_completions*
+By default vim-lsc will display completions that loosely substring match the
+entered word characters. To display matches that strictly prefix match the
+entered word characters please set `g:lsc_prefix_match_completions` to `v:true`.
+
 AUTOCMDS                                        *lsc-autocmds*
 
                                                 *autocmd-LSCAutocomplete*

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -16,6 +16,9 @@ endif
 if !exists('g:lsc_enable_snippet_support')
   let g:lsc_enable_snippet_support = v:false
 endif
+if !exists('g:lsc_prefix_match_completions')
+  let g:lsc_prefix_match_completions = v:false
+endif
 
 command! LSClientGoToDefinitionSplit
     \ call lsc#reference#goToDefinition(<q-mods>, 1)


### PR DESCRIPTION
LSC completions are currently filtered via case-insensitive substring
matching.

A new user option, g:lsc_prefix_match_completions, can be set to
`v:true` which will instead filter completions via stricter prefix matching.

This new option aligns with traditional omni and keyword completion
behaviour provided by Vim.

However, legacy substring completions remains the default.
The new stricter prefix completions need to be enabled via the option.