### PR TITLE
Prioritize completions with a prefix match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Add autocmd `User LSCDiagnosticsChange` to trigger when diagnostics are
   received.
 - Add support for a custom action menu with `g:LSC_action_menu`.
+- Sort completion suggestions that match by prefix higher than those that match
+  by substring.
 
 # 0.3.2
 

--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -203,18 +203,25 @@ function! s:FindSuggestions(base, completion) abort
 endfunction
 
 function! s:FilterAndSort(base, items) abort
+  let l:prefix_case_matches = []
   let l:prefix_matches = []
   let l:substring_matches = []
+  let l:substring_case_matches = []
   let l:prefix_base = '^'.a:base
   for l:item in a:items
     let l:word = type(l:item) == type({}) ? l:item.word : l:item
-    if l:word =~? l:prefix_base
+    if l:word =~# l:prefix_base
+      call add(l:prefix_case_matches, l:word)
+    elseif l:word =~? l:prefix_base
       call add(l:prefix_matches, l:word)
+    elseif l:word =~# a:base
+      call add(l:substring_case_matches, l:word)
     elseif l:word =~? a:base
       call add(l:substring_matches, l:word)
     endif
   endfor
-  return l:prefix_matches + l:substring_matches
+  return l:prefix_case_matches + l:prefix_matches +
+      \ l:substring_case_matches + l:substring_matches
 endfunction
 
 " Normalize LSP completion suggestions to the format used by vim.

--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -199,13 +199,22 @@ endfunction
 function! s:FindSuggestions(base, completion) abort
   let items = copy(a:completion.items)
   if len(a:base) == 0 | return items | endif
-  return filter(items, {_, item -> s:MatchSuggestion(a:base, item)})
+  return s:FilterAndSort(a:base, l:items)
 endfunction
 
-function! s:MatchSuggestion(base, suggestion) abort
-  let word = a:suggestion
-  if type(word) == type({}) | let word = word.word | endif
-  return word =~? a:base
+function! s:FilterAndSort(base, items) abort
+  let l:prefix_matches = []
+  let l:substring_matches = []
+  let l:prefix_base = '^'.a:base
+  for l:item in a:items
+    let l:word = type(l:item) == type({}) ? l:item.word : l:item
+    if l:word =~? l:prefix_base
+      call add(l:prefix_matches, l:word)
+    elseif l:word =~? a:base
+      call add(l:substring_matches, l:word)
+    endif
+  endfor
+  return l:prefix_matches + l:substring_matches
 endfunction
 
 " Normalize LSP completion suggestions to the format used by vim.

--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -206,7 +206,6 @@ function! s:FilterAndSort(base, items) abort
   let l:prefix_case_matches = []
   let l:prefix_matches = []
   let l:substring_matches = []
-  let l:substring_case_matches = []
   let l:prefix_base = '^'.a:base
   for l:item in a:items
     let l:word = type(l:item) == type({}) ? l:item.word : l:item
@@ -214,14 +213,11 @@ function! s:FilterAndSort(base, items) abort
       call add(l:prefix_case_matches, l:word)
     elseif l:word =~? l:prefix_base
       call add(l:prefix_matches, l:word)
-    elseif l:word =~# a:base
-      call add(l:substring_case_matches, l:word)
     elseif l:word =~? a:base
       call add(l:substring_matches, l:word)
     endif
   endfor
-  return l:prefix_case_matches + l:prefix_matches +
-      \ l:substring_case_matches + l:substring_matches
+  return l:prefix_case_matches + l:prefix_matches + l:substring_matches
 endfunction
 
 " Normalize LSP completion suggestions to the format used by vim.


### PR DESCRIPTION
Towards #226

Group matching suggestions into 2 categories - those that match by
prefix and those that match by substring. Sort the prefix matched items
first in the suggestion list.