### PR TITLE
Allow syntax highlighting in hover popup

### DIFF
--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -145,7 +145,7 @@ function! s:showHover(result) abort
       if has_key(item, 'language')
         let l:filetype = item.language
       elseif has_key(item, 'kind')
-        let l:filetype = item.kind == 'markdown' ? 'markdown' : 'text'
+        let l:filetype = item.kind ==# 'markdown' ? 'markdown' : 'text'
       endif
     else
       let l:lines += split(item, "\n")
@@ -169,7 +169,7 @@ function! s:openHoverPopup(lines, filetype) abort
   if has('nvim')
     let buf = nvim_create_buf(v:false, v:true)
     call nvim_buf_set_option(buf, 'synmaxcol', 0)
-    if exists('g:lsc_enable_popup_syntax') && g:lsc_enable_popup_syntax
+    if g:lsc_enable_popup_syntax
       call nvim_buf_set_option(buf, 'filetype', a:filetype)
     endif
     " Note, the +2s below will be used for padding around the hover text.
@@ -236,7 +236,7 @@ function! s:openHoverPopup(lines, filetype) abort
           \ 'border': [0, 0, 0, 0],
           \ 'moved': 'any',
           \ })
-    if exists('g:lsc_enable_popup_syntax') && g:lsc_enable_popup_syntax
+    if g:lsc_enable_popup_syntax
       call setbufvar(winbufnr(s:popup_id), '&filetype', a:filetype)
     endif
   end

--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -145,7 +145,7 @@ function! s:showHover(result) abort
       if has_key(item, 'language')
         let l:filetype = item.language
       elseif has_key(item, 'kind')
-        let l:filetype = item.kind
+        let l:filetype = item.kind == 'markdown' ? 'markdown' : 'text'
       endif
     else
       let l:lines += split(item, "\n")

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -384,9 +384,9 @@ action should be run, skip the call to the passed callback. This may be used,
 for example, to add in fuzzy finding of actions instead of a numbered selection.
 
                                                 *g:lsc_enable_popup_syntax*
-By default vim-lsc will not syntax highlight content displayed in popups, for
-example when invoking |:LSClientShowHover|. To display content with syntax
-highlighting, if applicable, please set `g:lsc_popup_syntax` to `v:true`.
+By default vim-lsc will syntax highlight content displayed in popups, for
+example when invoking |:LSClientShowHover|. To disable such syntax highlighting
+please set `g:lsc_popup_syntax` to `v:false`.
 
 AUTOCMDS                                        *lsc-autocmds*
 

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -383,6 +383,11 @@ a `title` field) and the callback to invoke an action after it is chosen. If no
 action should be run, skip the call to the passed callback. This may be used,
 for example, to add in fuzzy finding of actions instead of a numbered selection.
 
+                                                *g:lsc_enable_popup_syntax*
+By default vim-lsc will not syntax highlight content displayed in popups, for
+example when invoking |:LSClientShowHover|. To display content with syntax
+highlighting, if applicable, please set `g:lsc_popup_syntax` to `v:true`.
+
 AUTOCMDS                                        *lsc-autocmds*
 
                                                 *autocmd-LSCAutocomplete*

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -16,6 +16,9 @@ endif
 if !exists('g:lsc_enable_snippet_support')
   let g:lsc_enable_snippet_support = v:false
 endif
+if !exists('g:lsc_enable_popup_syntax')
+  let g:lsc_enable_popup_syntax = v:true
+endif
 
 command! LSClientGoToDefinitionSplit
     \ call lsc#reference#goToDefinition(<q-mods>, 1)


### PR DESCRIPTION
Certain language servers return hover details in markdown (e.g. the Dart language server).

Certain language servers return hover details with a specific language tag (e.g TSServer which sets typescript filetype).

Currently LSC always displays hover details in plain text with no highlighting.

This commit provides a new option, `g:lsc_enable_popup_syntax`, that indicates we prefer to syntax highlight if possible. LSP servers can return content is a string, but it is really markdown (Dart LSP), whilst other language servers do provide a hint either in `content.language` or `content.kind`. We default to using markdown, which should be fine, even for plain-text, and then we override if the language server provides a language or kind hint.

TSServer sets `content.language`
Ruby Solargraph sets `content.kind`
Dart set no tag, but always appears to return a markdown-ized string.

I cross referenced against vim-lsp and it does roughly the same processing, default to markdown and then allow overrides from the language server.

Implemented for both Vim and Neovim using their 2 different APIs.
The result really is visually nice.

At the same I tweaked the Neovim float again:

- Very tall floats are forced to always display below the cursor line like Vim,  no more overflows

- Floats are now focussable which allows scrolling content inside the float which is very very important (no unreachable content of the end of the screen). Once focussed a simple Esc is all thats needed to dismiss the popup. If never focussed into the same dismiss behavior remains via
  CursorMoved.

Note, I don't know how to scroll content inside Vim popups. Hopefully that is doable, but I could not find it.