### PR TITLE
Avoid restarting completion after picking a word

### DIFF
--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -64,7 +64,7 @@ endfunction
 augroup LscCompletion
   autocmd!
   autocmd CompleteDone * let b:lsc_is_completing = v:false
-      \ | silent! unlet b:lsc_completion
+      \ | silent! unlet b:lsc_completion | let s:next_char = ''
 augroup END
 
 " Whether the cursor follows a minimum count of  word characters, and completion


### PR DESCRIPTION
Fixes #244

We get another `TextChangedI` after hitting "enter" to choose a
completion. Since `s:next_char` was still set to whatever character was
typed last during the completion, we think we need to complete again.
Emptying out `s:next_char` avoids this.