### PR TITLE
Hover floating window improvements for Neovim

### DIFF
--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -175,16 +175,19 @@ function! s:openHoverPopup(lines, filetype) abort
     " Note, the +2s below will be used for padding around the hover text.
     let height = len(a:lines) + 2
     let width = 1
+    " The maximum width of the floating window should not exceed 95% of the
+    " screen width.
+    let max_width = float2nr(&columns * 0.95)
+
     " Need to figure out the longest line and base the popup width on that.
     " Also increase the floating window 'height' if any lines are going to wrap.
     for val in a:lines
       let val_width = strdisplaywidth(val) + 2
-      if val_width > width
-        let width = val_width
+      if val_width > max_width
+        let height = height + (val_width / max_width)
+        let val_width = max_width
       endif
-      if val_width > &columns
-        let height = height + (val_width / &columns)
-      endif
+      let width = val_width > width ? val_width : width
     endfor
 
     " Prefer an upward floating window, but if there is no space fallback to
@@ -203,8 +206,8 @@ function! s:openHoverPopup(lines, filetype) abort
       " Truncate the float height so that the popup always floats below and
       " never overflows into and above the cursor line.
       let lines_above_cursor = current_position[1] - top_line_number
-      if height > &lines - lines_above_cursor
-        let height = &lines - lines_above_cursor - 2
+      if height > winheight(0) + 2 - lines_above_cursor
+        let height = winheight(0) - lines_above_cursor
       endif
     endif
 


### PR DESCRIPTION
The maximum width of a hover floating window should not exceed 95% of
the screen size. This looks visually pleasing compared with 100% wide
hover window. It floats more at max 95%.

Secondly fix overflow issues, the max height of the float should be based on
the window height not the screen height. Horizontal split windows
broke my previous float up or float down sizing logic. Now that is no
longer an issue. There should no longer be overflowing hover windows
that shallow the cursor line. Either the hover window will float above
the cursor line or below.