### PR TITLE
TailwindCSS Language Server compatibility

### DIFF
--- a/autoload/lsc/protocol.vim
+++ b/autoload/lsc/protocol.vim
@@ -62,9 +62,10 @@ function! s:Consume(server) abort
     return v:false
   endif
   let headers = split(message[:end_of_header - 1], "\r\n")
-  if headers[0] =~ '^[]'
+  if headers[0] =~? '^[]'
     let headers[0] = headers[0][3:]
   endif
+  let g:headers = headers
   let l:message_start = end_of_header + len("\r\n\r\n")
   let l:message_end = l:message_start + s:ContentLength(headers)
   if len(message) < l:message_end

--- a/autoload/lsc/protocol.vim
+++ b/autoload/lsc/protocol.vim
@@ -62,6 +62,9 @@ function! s:Consume(server) abort
     return v:false
   endif
   let headers = split(message[:end_of_header - 1], "\r\n")
+  if headers[0] =~ '^[]'
+    let headers[0] = headers[0][3:]
+  endif
   let l:message_start = end_of_header + len("\r\n\r\n")
   let l:message_end = l:message_start + s:ContentLength(headers)
   if len(message) < l:message_end


### PR DESCRIPTION
Hi Nate,

I've been trying to use the `tailwindcss-language-server`, the following snippet fixes it to work with vim-lsc.

The problem seems to be that the headers passed from the language server begins with an array e.g:
```
['[]
Content-Length: 184']
```

With the included if statement this gets removed, resulting in:
```
['Content-Length: 106']
```

I checked another server, `typescript-language-server` to make sure the change didn't break a previously working example.

I looked for some contributor guidelines but found none, I'd love to help get this working for other people.