### PR TITLE
Fix for snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,6 @@ a function call. The currently active parameter is highlighted with the group
 
 - [vista.vim](https://github.com/liuchengxu/vista.vim)
 - [deoplete-vim-lsc](https://github.com/hrsh7th/deoplete-vim-lsc)
+- [vim-vsnip](https://github.com/hrsh7th/vim-vsnip)
+- [vim-vsnip-integ](https://github.com/hrsh7th/vim-vsnip-integ)
+

--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -210,11 +210,11 @@ function! s:FilterAndSort(base, items) abort
   for l:item in a:items
     let l:word = type(l:item) == type({}) ? l:item.word : l:item
     if l:word =~# l:prefix_base
-      call add(l:prefix_case_matches, l:word)
+      call add(l:prefix_case_matches, l:item)
     elseif l:word =~? l:prefix_base
-      call add(l:prefix_matches, l:word)
+      call add(l:prefix_matches, l:item)
     elseif l:word =~? a:base
-      call add(l:substring_matches, l:word)
+      call add(l:substring_matches, l:item)
     endif
   endfor
   return l:prefix_case_matches + l:prefix_matches + l:substring_matches
@@ -272,6 +272,7 @@ function! s:CompletionItem(completion_item) abort
           \ 'snippet': item.word,
           \ 'snippet_trigger': item.word
           \ })
+    let l:item.word = a:completion_item.label
   endif
   if has_key(a:completion_item, 'kind')
     let item.kind = s:CompletionItemKind(a:completion_item.kind)


### PR DESCRIPTION
I created `vim-vsnip`/`vim-vsnip-integ` that provides LSP style snippet feature and `vim-lsc` integration.

I found the integrations broken by recently commits.
This PR aims to fix those integrations.