### PR TITLE
Add a filetype to the preview window

### DIFF
--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -166,12 +166,13 @@ function! s:showHover(force_preview, result) abort
         \ && (exists('*popup_atcursor') || exists('*nvim_open_win'))
     call s:closeHoverPopup()
     if (a:force_preview)
-      call lsc#util#displayAsPreview(lines, function('lsc#util#noop'))
+      call lsc#util#displayAsPreview(lines, l:filetype,
+          \ function('lsc#util#noop'))
     else
       call s:openHoverPopup(l:lines, l:filetype)
     endif
   else
-    call lsc#util#displayAsPreview(lines, function('lsc#util#noop'))
+    call lsc#util#displayAsPreview(lines, l:filetype, function('lsc#util#noop'))
   endif
 endfunction
 

--- a/autoload/lsc/signaturehelp.vim
+++ b/autoload/lsc/signaturehelp.vim
@@ -47,7 +47,8 @@ function! s:ShowHelp(signatureHelp) abort
   endif
 
   if !has_key(signature, 'parameters')
-    call lsc#util#displayAsPreview([signature.label], function('<SID>HighlightCurrentParameter'))
+    call lsc#util#displayAsPreview([signature.label], 'text',
+        \ function('<SID>HighlightCurrentParameter'))
     return
   endif
 
@@ -59,6 +60,7 @@ function! s:ShowHelp(signatureHelp) abort
     endif
   endif
 
-  call lsc#util#displayAsPreview([signature.label], function('<SID>HighlightCurrentParameter'))
+  call lsc#util#displayAsPreview([signature.label], 'text',
+      \ function('<SID>HighlightCurrentParameter'))
 
 endfunction

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -82,12 +82,13 @@ endfunction
 " otherwise split a window with a max height of `&previewheight`.
 " After the content of the content of the preview window is set,
 " `function` is called (the buffer is still the preview).
-function! lsc#util#displayAsPreview(lines, function) abort
+function! lsc#util#displayAsPreview(lines, filetype, function) abort
   let view = winsaveview()
   let alternate=@#
   call s:createOrJumpToPreview(s:countDisplayLines(a:lines, &previewheight))
   %d
   call setline(1, a:lines)
+  let &filetype = a:filetype
   call a:function()
   wincmd p
   call winrestview(view)


### PR DESCRIPTION
Set the filetype after adding content in the preview window buffer to
get syntax highlighting.