### PR TITLE
Prepend completion item detail to info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Add support for a custom action menu with `g:LSC_action_menu`.
 - Sort completion suggestions that match by prefix higher than those that match
   by substring.
+- Include Completion item `detail` field in the preview window.
 
 # 0.3.2
 

--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -281,14 +281,20 @@ function! s:CompletionItem(completion_item) abort
     let detail_lines = split(a:completion_item.detail, "\n")
     if len(detail_lines) > 0
       let item.menu = detail_lines[0]
+      let l:item.info = a:completion_item.detail
     endif
   endif
   if has_key(a:completion_item, 'documentation')
     let documentation = a:completion_item.documentation
+    if has_key(l:item, 'info')
+      let l:item.info .= "\n\n"
+    else
+      let l:item.info = ''
+    endif
     if type(documentation) == type('')
-      let item.info = documentation
+      let l:item.info .= documentation
     elseif type(documentation) == type({}) && has_key(documentation, 'value')
-      let item.info = documentation.value
+      let l:item.info .= documentation.value
     endif
   endif
   return item


### PR DESCRIPTION
Closes #266

The 'detail' field is intended to be human readable. Previously we had
only included the first line in the menu, now include the full text in
the preview window. This will precede the documentation, if any exists.