### PR TITLE
Allow configuring clientCapabilities.hover.contentFormat

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -186,6 +186,7 @@ function! s:ClientCapabilities() abort
     \       'codeActionKind': {'valueSet': ['quickfix', 'refactor', 'source']}
     \     }
     \   },
+    \   'hover': {'contentFormat': g:lsc_hover_contentformat},
     \   'signatureHelp': {'dynamicRegistration': v:false},
     \ }
     \}

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -398,6 +398,15 @@ By default vim-lsc will syntax highlight content displayed in popups, for
 example when invoking |:LSClientShowHover|. To disable such syntax highlighting
 please set `g:lsc_popup_syntax` to `v:false`.
 
+                                                *g:lsc_hover_contentformat*
+By default vim-lsc will indicate to the server that it supports both markdown
+and plaintext content formats for hover results. To override this, set
+`clientCapabilities.hover.contentFormat` in order of preference:
+>
+ " Prefer plaintext over markdown
+ let g:lsc_hover_contentformat = ['plaintext', 'markdown']
+<
+
 AUTOCMDS                                        *lsc-autocmds*
 
                                                 *autocmd-LSCAutocomplete*

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -19,6 +19,9 @@ endif
 if !exists('g:lsc_enable_popup_syntax')
   let g:lsc_enable_popup_syntax = v:true
 endif
+if !exists('g:lsc_hover_contentformat')
+  let g:lsc_hover_contentformat = ['markdown', 'plaintext']
+endif
 
 command! LSClientGoToDefinitionSplit
     \ call lsc#reference#goToDefinition(<q-mods>, 1)


### PR DESCRIPTION
(This is specific to `gopls 0.4.0` but I imagine any other language server which supports returning markdown may exhibit similar behaviour.)

If an client does not send `clientCapabilities.hover.contentFormat`, the server defaults to returning markdown. This is the result of `LSClientShowHover` in a Go file:

<img width="464" alt="Screen Shot 2020-04-21 at 15 59 23" src="https://user-images.githubusercontent.com/220451/79926682-6222e600-83f2-11ea-87cd-6553536a71f9.png">

Even with `concceallevel=2`, it's still not a great experience:

<img width="638" alt="Screen Shot 2020-04-21 at 16 49 50" src="https://user-images.githubusercontent.com/220451/79926450-d1e4a100-83f1-11ea-8c46-e69258d1caa1.png">

I realise this heavily depends on a user's vim setup and personal preference, however I think allowing the option to modify it while keeping the current default should satisfy most needs.

This is both my first experience with the LSP specification and vimscript (outside of my own `.vimrc`), so there's a high chance this is not the most idiomatic way to achieve this so I welcome any feedback.