### PR TITLE
Expose last preview in b:lsc_last_preview

### DIFF
--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -162,7 +162,7 @@ function! s:showHover(force_preview, result) abort
       let l:lines += split(item, "\n")
     endif
   endfor
-  let b:lsc_last_preview = l:lines
+  let b:lsc_last_hover = l:lines
   if get(g:, 'lsc_hover_popup', v:true) 
         \ && (exists('*popup_atcursor') || exists('*nvim_open_win'))
     call s:closeHoverPopup()

--- a/autoload/lsc/reference.vim
+++ b/autoload/lsc/reference.vim
@@ -162,6 +162,7 @@ function! s:showHover(force_preview, result) abort
       let l:lines += split(item, "\n")
     endif
   endfor
+  let b:lsc_last_preview = l:lines
   if get(g:, 'lsc_hover_popup', v:true) 
         \ && (exists('*popup_atcursor') || exists('*nvim_open_win'))
     call s:closeHoverPopup()


### PR DESCRIPTION
This exposes the last preview item in a buffer variable; the use case
for this is that I'd like to display the last function signature in the
statusline like so:

	let &statusline .= '%{get(get(b:, "lsc_last_preview", []), 0, "")}'

I'm not sure if there is any other way to do this?