### PR TITLE
Conditional ExitPre autocommand

### DIFF
--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -107,7 +107,9 @@ augroup LSC
   autocmd InsertCharPre * call <SID>IfEnabled('lsc#complete#insertCharPre')
 
   autocmd VimLeave * call lsc#server#exit()
-  autocmd ExitPre * let g:_lsc_is_exiting = v:true
+  if exists('##ExitPre')
+    autocmd ExitPre * let g:_lsc_is_exiting = v:true
+  endif
 augroup END
 
 " Set window local state only if this is a brand new window which has not


### PR DESCRIPTION
Fixes #276

Since this is an optimization to avoid sending extra `didClose` messages
it should be safe to skip it altogether. I'm not sure if there is
another event that would work for this purpose.

Check that `ExitPre` exists as an event before adding an `autocmd` for
it.