### PR TITLE
Don't send didSave if capability is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   send any items containing a `textEdit` field.
 - Truncate diagnostics at 1 character shorter for when `ruler` is used.
 - Normalize windows file path separators to create valid URIs.
+- Don't send `textDocument/didSave` notifications if the server does not
+  advertise them as a capability.
 
 **Minor breaking changes**
 - Server dictionaries no longer expose their full `init_results`, or their call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Truncate diagnostics at 1 character shorter for when `ruler` is used.
 - Normalize windows file path separators to create valid URIs.
 - Don't send `textDocument/didSave` notifications if the server does not
-  advertise them as a capability.
+  advertise it as a capability.
 
 **Minor breaking changes**
 - Server dictionaries no longer expose their full `init_results`, or their call

--- a/autoload/lsc/capabilities.vim
+++ b/autoload/lsc/capabilities.vim
@@ -16,19 +16,16 @@ function! lsc#capabilities#normalize(capabilities) abort
   if has_key(a:capabilities, 'textDocumentSync')
     let l:text_document_sync = a:capabilities['textDocumentSync']
     let l:incremental = v:false
-    let l:send_did_save = v:true
     if type(l:text_document_sync) == type({})
       if has_key(l:text_document_sync, 'change')
         let l:incremental = l:text_document_sync['change'] == 2
       endif
-      if !has_key(l:text_document_sync, 'save')
-        let l:send_did_save = v:false
-      endif
+      let l:normalized.textDocumentSync.sendDidSave =
+          \ has_key(l:text_document_sync, 'save')
     else
       let l:incremental = l:text_document_sync == 2
     endif
     let l:normalized.textDocumentSync.incremental = l:incremental
-    let l:normalized.textDocumentSync.sendDidSave = l:send_did_save
   endif
   if has_key(a:capabilities, 'documentHighlightProvider')
     let l:normalized.referenceHighlights =

--- a/test/integration/pubspec.yaml
+++ b/test/integration/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  lsp: ^0.1.0
+  lsp: ^0.1.1
   path: ^1.7.0
 
 dev_dependencies:

--- a/test/integration/test/did_save_test.dart
+++ b/test/integration/test/did_save_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:_test/vim_remote.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:lsp/lsp.dart' show lspChannel;
+import 'package:test/test.dart';
+
+void main() {
+  Stream<Peer> clients;
+  ServerSocket serverSocket;
+  Vim vim;
+  Peer client;
+
+  setUpAll(() async {
+    serverSocket = await ServerSocket.bind('localhost', 0);
+
+    clients = serverSocket.map((socket) {
+      return Peer(lspChannel(socket, socket), onUnhandledError: (error, stack) {
+        fail('Unhandled server error: $error');
+      });
+    }).asBroadcastStream();
+    vim = await Vim.start();
+    await vim.expr('RegisterLanguageServer("text", {'
+        '"command":"localhost:${serverSocket.port}",'
+        '"enabled":v:false,'
+        '})');
+  });
+
+  setUp(() async {
+    final nextClient = clients.first;
+    await vim.edit('foo.txt');
+    await vim.sendKeys(':LSClientEnable<cr>');
+    client = await nextClient;
+  });
+
+  tearDown(() async {
+    await vim.sendKeys(':LSClientDisable<cr>');
+    await vim.sendKeys(':bwipeout<cr>');
+    final file = File('foo.txt');
+    if (await file.exists()) await file.delete();
+  });
+
+  tearDownAll(() async {
+    await vim.quit();
+    print(File(vim.name).readAsStringSync());
+    await serverSocket.close();
+  });
+
+  Future<void> testNoDidSave(Map<String, dynamic> capabilities) async {
+    final didOpen = Completer<Parameters>();
+    final didSave = Completer<Parameters>()
+      ..future.then((_) {
+        fail('Unexpected didSave');
+      });
+    final didChange = Completer<Parameters>();
+    client
+      ..registerLifecycleMethods(capabilities)
+      ..registerMethod(
+          'textDocument/didOpen', (params) => didOpen.complete(params))
+      ..registerMethod(
+          'textDocument/didSave', (params) => didSave.complete(params))
+      ..registerMethod(
+          'textDocument/didChange', (params) => didChange.complete(params))
+      ..listen();
+
+    await didOpen.future;
+
+    await vim.sendKeys(':w<cr>');
+
+    await vim.sendKeys('iHello<esc>');
+    await didChange.future;
+  }
+
+  test('TextDocumentSyncKind instead of TextDocumentSyncOptions', () async {
+    await testNoDidSave({'textDocumentSync': 1});
+  });
+
+  test('omitted sync key', () async {
+    await testNoDidSave({
+      'textDocumentSync': {'openClose': true, 'change': 1}
+    });
+  });
+
+  test('include sync key', () async {
+    final didOpen = Completer<Parameters>();
+    final didSave = Completer<Parameters>();
+    client
+      ..registerLifecycleMethods({
+        'textDocumentSync': {'openClose': true, 'save': {}}
+      })
+      ..registerMethod(
+          'textDocument/didOpen', (params) => didOpen.complete(params))
+      ..registerMethod(
+          'textDocument/didSave', (params) => didSave.complete(params))
+      ..listen();
+
+    await didOpen.future;
+
+    await vim.sendKeys(':w<cr>');
+
+    await didSave.future;
+  });
+}
+
+extension LSP on Peer {
+  void registerLifecycleMethods(Map<String, dynamic> capabilities) {
+    registerMethod('initialize', (params) {
+      return {'capabilities': capabilities};
+    });
+    registerMethod('initialized', (_) {});
+    registerMethod('shutdown', (_) {});
+    registerMethod('exit', (_) {
+      close();
+    });
+  }
+}


### PR DESCRIPTION
Fixes #275

Only set the `sendDidSave` config if the server sends the
`textDocumentSync.save` key, otherwise retain the default which is
`v:false`. Omitting any key, or sending a non-dict, should be considered
as an absent capability.

The `includeText` sub-property of the `SaveOptions` interface is not
supported, so we still only check whether the key is present.