### PR TITLE
Fix some test flakiness

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -30,16 +30,17 @@ function! lsc#file#onOpen() abort
 endfunction
 
 function! lsc#file#onClose(full_path, filetype) abort
-  let l:params = {'textDocument': {'uri': lsc#uri#documentUri(a:full_path)}}
-  for l:server in lsc#server#forFileType(a:filetype)
-    call l:server.notify('textDocument/didClose', l:params)
-  endfor
   if has_key(s:file_versions, a:full_path)
     unlet s:file_versions[a:full_path]
   endif
   if has_key(s:file_content, a:full_path)
     unlet s:file_content[a:full_path]
   endif
+  if !lsc#server#filetypeActive(a:filetype) | return | endif
+  let l:params = {'textDocument': {'uri': lsc#uri#documentUri(a:full_path)}}
+  for l:server in lsc#server#forFileType(a:filetype)
+    call l:server.notify('textDocument/didClose', l:params)
+  endfor
 endfunction
 
 " Send a `textDocument/didSave` notification if the server may be interested.

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -167,7 +167,6 @@ function! s:OnClose() abort
   if g:_lsc_is_exiting | return | endif
   let l:filetype = getbufvar(str2nr(expand('<abuf>')), '&filetype')
   if !has_key(g:lsc_servers_by_filetype, l:filetype) | return | endif
-  if !lsc#server#filetypeActive(l:filetype) | return | endif
   let l:full_path = lsc#file#normalize(expand('<afile>:p'))
   call lsc#file#onClose(l:full_path, l:filetype)
 endfunction

--- a/test/integration/test/did_save_test.dart
+++ b/test/integration/test/did_save_test.dart
@@ -36,14 +36,18 @@ void main() {
 
   tearDown(() async {
     await vim.sendKeys(':LSClientDisable<cr>');
-    await vim.sendKeys(':bwipeout<cr>');
+    await vim.sendKeys(':%bwipeout!<cr>');
     final file = File('foo.txt');
     if (await file.exists()) await file.delete();
+    await client.done;
+    client = null;
   });
 
   tearDownAll(() async {
     await vim.quit();
-    print(File(vim.name).readAsStringSync());
+    final log = File(vim.name);
+    print(await log.readAsString());
+    await log.delete();
     await serverSocket.close();
   });
 

--- a/test/integration/test/vim_test.dart
+++ b/test/integration/test/vim_test.dart
@@ -17,7 +17,9 @@ void main() {
 
     tearDownAll(() async {
       await vim.quit();
-      print(File(vim.name).readAsStringSync());
+      final log = File(vim.name);
+      print(await log.readAsString());
+      await log.delete();
     });
 
     test('evaluates expressions', () async {


### PR DESCRIPTION
Clear out file state even for disabled servers on BufUnload. Without
this when re-enabling the server the `didOpen` message would not be sent
so the test would hang waiting for it.

Use wipeout all buffers with a bang for safety in the test teardown.

Wait for clients to close on test teardown.

Clean up log files after printing them.