### PR TITLE
Implement line difference search in lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
   by substring.
 - Include Completion item `detail` field in the preview window.
 - Strikethrough deprecated completion options in the menu.
+- Improve performance of finding incremental changes for file syncing in very
+  large files when lua support is available.
 
 # 0.3.2
 

--- a/autoload/lsc/diff.vim
+++ b/autoload/lsc/diff.vim
@@ -27,21 +27,21 @@ function! lsc#diff#compute(old, new) abort
   return result
 endfunction
 
-if has('lua') && !exists('s:lua')
+if (has('lua') || has('nvim')) && !exists('s:lua')
   lua <<EOF
-  function lsc_last_difference(old, new)
+  function lsc_last_difference(old, new, offset)
     local length = math.min(#old, #new)
     for i = 0, length - 1 do
-      if old[#old-i] ~= new[#new-i] then
+      if old[#old - i + offset] ~= new[#new - i + offset] then
         return -1 * i
       end
     end
     return -1 * length
   end
-  function lsc_first_difference(old, new)
+  function lsc_first_difference(old, new, offset)
     local length = math.min(#old, #new)
     for i = 1, length do
-      if old[i] ~= new[i] then
+      if old[i + offset] ~= new[i + offset] then
         return i
       end
     end
@@ -55,9 +55,10 @@ let s:lua = 1
 " list of Strings.
 function! s:FirstDifference(old, new) abort
   let line_count = min([len(a:old), len(a:new)])
-  if has('lua')
-    let l:i =
-        \ luaeval('lsc_first_difference(vim.eval("a:old"), vim.eval("a:new"))')
+  if has('lua') || has('nvim')
+    let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
+    let l:i = luaeval('lsc_first_difference('
+        \.l:eval.'("a:old"),'.l:eval.'("a:new"),'.l:eval.'("has(\"nvim\")"))')
   else
     let i = 0
     while i < line_count
@@ -82,9 +83,10 @@ endfunction
 function! s:LastDifference(old, new, start_char) abort
   let line_count = min([len(a:old), len(a:new)])
   if line_count == 0 | return [0, 0] | endif
-  if has('lua')
-    let l:i =
-        \ luaeval('lsc_last_difference(vim.eval("a:old"), vim.eval("a:new"))')
+  if has('lua') || has('nvim')
+    let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
+    let l:i = luaeval('lsc_last_difference('
+        \.l:eval.'("a:old"),'.l:eval.'("a:new"),'.l:eval.'("has(\"nvim\")"))')
   else
     let i = -1
     while i >= -1 * line_count

--- a/autoload/lsc/diff.vim
+++ b/autoload/lsc/diff.vim
@@ -27,7 +27,9 @@ function! lsc#diff#compute(old, new) abort
   return result
 endfunction
 
-if (has('lua') || has('nvim')) && !exists('s:lua')
+let s:has_lua = has('lua') || has('nvim-0.4.0')
+
+if s:has_lua && !exists('s:lua')
   lua <<EOF
   function lsc_last_difference(old, new, offset)
     local length = math.min(#old, #new)
@@ -55,7 +57,7 @@ let s:lua = 1
 " list of Strings.
 function! s:FirstDifference(old, new) abort
   let line_count = min([len(a:old), len(a:new)])
-  if has('lua') || has('nvim')
+  if s:has_lua
     let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
     let l:i = luaeval('lsc_first_difference('
         \.l:eval.'("a:old"),'.l:eval.'("a:new"),'.l:eval.'("has(\"nvim\")"))')
@@ -83,7 +85,7 @@ endfunction
 function! s:LastDifference(old, new, start_char) abort
   let line_count = min([len(a:old), len(a:new)])
   if line_count == 0 | return [0, 0] | endif
-  if has('lua') || has('nvim')
+  if s:has_lua
     let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
     let l:i = luaeval('lsc_last_difference('
         \.l:eval.'("a:old"),'.l:eval.'("a:new"),'.l:eval.'("has(\"nvim\")"))')


### PR DESCRIPTION
Fixes #273

For very large files with a small edit the diff computation spends most
of it's time verifying the equality of the lines before and after the
difference, lua is much faster to iterate the collections and compare
strings. Add a small function to give a faster path for finding the
index of the first and last line with a difference in lua.