### PR TITLE
printf with only one argument on vim < 8.0.1557

### DIFF
--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -187,7 +187,7 @@ function! s:GoToChar(pos) abort
   let l:cmd = ''
   let l:cmd .= printf('%dG', a:pos.line + 1)
   if a:pos.character == 0
-    let l:cmd .= printf('0')
+    let l:cmd .= '0'
   else
     let l:cmd .= printf('0%dl', a:pos.character)
   endif


### PR DESCRIPTION
Don't know your support plan for Vim versions, but despite this problem was corrected a long long time ago (https://github.com/vim/vim/commit/c71807db9c1821baf86796cd76952df36ff1a29a), Ubuntu 18.04 LTS (supported until April 2023) comes only with version 8.0.1453.

Thanks for bringing LSP power to Vim ! Hope this small contribution would help.