### PR TITLE
Use for-in-range loop instead of while loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@
   by substring.
 - Include Completion item `detail` field in the preview window.
 - Strikethrough deprecated completion options in the menu.
-- Improve performance of finding incremental changes for file syncing in very
-  large files when lua support is available.
+- Improve performance of finding incremental changes for file syncing in large
+  files.
 
 # 0.3.2
 

--- a/autoload/lsc/diff.vim
+++ b/autoload/lsc/diff.vim
@@ -27,54 +27,14 @@ function! lsc#diff#compute(old, new) abort
   return result
 endfunction
 
-let s:has_lua = has('lua') || has('nvim-0.4.0')
-
-if s:has_lua && !exists('s:lua')
-  lua <<EOF
-  -- Returns a zero-based index of the last line that is different between
-  -- old and new. If old and new are not zero indexed, pass offset to indicate
-  -- the index base.
-  function lsc_last_difference(old, new, offset)
-    local length = math.min(#old, #new)
-    for i = 0, length - 1 do
-      if old[#old - i + offset] ~= new[#new - i + offset] then
-        return -1 * i
-      end
-    end
-    return -1 * length
-  end
-  -- Returns a zero-based index of the first line that is different between
-  -- old and new. If old and new are not zero indexed, pass offset to indicate
-  -- the index base.
-  function lsc_first_difference(old, new, offset)
-    local length = math.min(#old, #new)
-    for i = 0, length - 1 do
-      if old[i + offset] ~= new[i + offset] then
-        return i
-      end
-    end
-    return length - 1
-  end
-EOF
-endif
-let s:lua = 1
-
 " Finds the line and character of the first different character between two
 " list of Strings.
 function! s:FirstDifference(old, new) abort
   let line_count = min([len(a:old), len(a:new)])
   if line_count == 0 | return [0, 0] | endif
-  if s:has_lua
-    let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
-    let l:i = luaeval('lsc_first_difference('
-        \.l:eval.'("a:old"),'.l:eval.'("a:new"),'.l:eval.'("has(\"nvim\")"))')
-  else
-    let i = 0
-    while i < line_count
-      if a:old[i] !=# a:new[i] | break | endif
-      let i += 1
-    endwhile
-  endif
+  for l:i in range(line_count)
+    if a:old[i] !=# a:new[i] | break | endif
+  endfor
   if i >= line_count
     return [line_count - 1, strchars(a:old[line_count - 1])]
   endif
@@ -92,17 +52,9 @@ endfunction
 function! s:LastDifference(old, new, start_char) abort
   let line_count = min([len(a:old), len(a:new)])
   if line_count == 0 | return [0, 0] | endif
-  if s:has_lua
-    let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
-    let l:i = luaeval('lsc_last_difference('
-        \.l:eval.'("a:old"),'.l:eval.'("a:new"),'.l:eval.'("has(\"nvim\")"))')
-  else
-    let i = -1
-    while i >= -1 * line_count
-      if a:old[i] !=# a:new[i] | break | endif
-      let i -= 1
-    endwhile
-  endif
+  for l:i in range(-1, -1 * line_count, -1)
+    if a:old[i] !=# a:new[i] | break | endif
+  endfor
   if i <= -1 * line_count
     let i = -1 * line_count
     let old_line = strcharpart(a:old[i], a:start_char)


### PR DESCRIPTION
See https://github.com/natebosch/vim-lsc/pull/282#issuecomment-633261524

Drop the lua implementation. It turns out using a for-in loop with a
range is even faster than calling in to lua, likely because it doesn't
need to copy over and set up the lua data structures.