### PR TITLE
Prefer plaintext for hover content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
 - Strikethrough deprecated completion options in the menu.
 - Improve performance of finding incremental changes for file syncing in very
   large files when lua support is available.
+- Send `hover.contentFormat` to prefer plaintext content which should be more
+  readable for most users.
 
 # 0.3.2
 

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -185,6 +185,7 @@ function! s:ClientCapabilities() abort
     \       'codeActionKind': {'valueSet': ['quickfix', 'refactor', 'source']}
     \     }
     \   },
+    \   'hover': {'contentFormat': ['plaintext', 'markdown']},
     \   'signatureHelp': {'dynamicRegistration': v:false},
     \ }
     \}


### PR DESCRIPTION
If a server supports a plaintext format it is likely to look nicer since
there isn't support for rendered markdown.

There is no configuration for now to avoid unnecessary noise - if users
ask for the ability to go back to preferring markdown we can add a
variable.

See https://github.com/natebosch/vim-lsc/pull/271