### PR TITLE
Honor `suppress_stder` during startup

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -271,11 +271,8 @@ function! lsc#server#register(filetype, config) abort
     call self._channel.request('initialize', l:params, a:callback)
   endfunction
   function! server.on_err(message) abort
-    if self.status ==# 'starting'
-        \ || !has_key(self.config, 'suppress_stderr')
-        \ || !self.config.suppress_stderr
-      call lsc#message#error('StdErr from '.self.config.name.': '.a:message)
-    endif
+    if get(self.config, 'suppress_stderr', v:false) | return | endif
+    call lsc#message#error('StdErr from '.self.config.name.': '.a:message)
   endfunction
   function! server.on_exit() abort
     unlet self._channel

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -453,10 +453,8 @@ only `'Log'` messages are suppressed. Set to `-1` to disable echo for any
 message.
 
                                                 *lsc-server-suppress_stderr*
-`'suppress_stderr'`: Set to `v:true` to suppress stderr output which is
-received after the server has been initialized. Stderr output before
-initialization still is shown in an error message. Use this if the server uses
-stderr for noisy status or logging.
+`'suppress_stderr'`: Set to `v:true` to suppress stderr output from the server.
+Use this if the server uses stderr for noisy status or logging.
 
                                                 *lsc-server-message_hooks*
 `'message_hooks'`: Set to a dictionary where the keys are LSP method names and

--- a/test/integration/test/stderr_test.dart
+++ b/test/integration/test/stderr_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:_test/vim_remote.dart';
+import 'package:test/test.dart';
+
+void main() {
+  Vim vim;
+  setUp(() async {
+    vim = await Vim.start();
+  });
+
+  tearDown(() async {
+    await vim.quit();
+    final log = File(vim.name);
+    print(await log.readAsString());
+    await log.delete();
+  });
+
+  test('emits stderr by default', () async {
+    await vim.expr('RegisterLanguageServer("text", {'
+        '"command":["sh", "-c", "echo messagestderr >&2"],'
+        '"name":"some server"'
+        '})');
+    await vim.edit('foo.txt');
+    while (await vim.expr('lsc#server#status(\'text\')') != 'failed') {
+      await Future.delayed(const Duration(milliseconds: 50));
+    }
+    final messages = await vim.messages(2);
+    expect(messages, [
+      '[lsc:Error] StdErr from some server: messagestderr',
+      '[lsc:Error] Failed to initialize server: some server'
+    ]);
+  });
+
+  test('suppresses stderr', () async {
+    await vim.expr('RegisterLanguageServer("text", {'
+        '"command":["sh", "-c", "echo messagestderr >&2"],'
+        '"name":"some server",'
+        '"suppress_stderr": v:true,'
+        '})');
+    await vim.edit('foo.txt');
+    while (await vim.expr('lsc#server#status(\'text\')') != 'failed') {
+      await Future.delayed(const Duration(milliseconds: 50));
+    }
+    final messages = await vim.messages(2);
+    expect(messages, [
+      '"foo.txt" [New file] --No lines in buffer--',
+      '[lsc:Error] Failed to initialize server: some server'
+    ]);
+  });
+}


### PR DESCRIPTION
Closes #290

Previously output before initialization was intended to be shown to
reduce the chances of hard to debug issues where the server crashes with
a message that is never seen. Since some servers emit noisy logs even
before initialization we can honor this always. In the future this will
change the default to suppress if the stderr can be logged elsewhere and
retrieved if necessary.