### PR TITLE
Fix error for server with list command and no name

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -229,7 +229,7 @@ function! lsc#server#register(filetype, config) abort
       throw 'Server configuration must have a "command" key'
     endif
     if !has_key(config, 'name')
-      let config.name = config.command
+      let config.name = string(config.command)
     endif
   endif
   let g:lsc_servers_by_filetype[a:filetype] = config.name

--- a/test/integration/test/early_exit_test.dart
+++ b/test/integration/test/early_exit_test.dart
@@ -21,8 +21,7 @@ void main() {
 
   test('reports a failure to start', () async {
     await vim.edit('foo.txt');
-    await Future.delayed(const Duration(seconds: 1));
     final messages = await vim.messages(1);
-    expect(messages, ['[lsc:Error] Failed to initialize server: false']);
+    expect(messages, ['[lsc:Error] Failed to initialize server: \'false\'']);
   });
 }


### PR DESCRIPTION
Non-strings can't be used as keys in a dict which is required to key by
name in `s:servers`.