### PR TITLE
Delay the conversion to vim completion items

### DIFF
--- a/test/integration/test/complete_test.dart
+++ b/test/integration/test/complete_test.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:_test/vim_remote.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:lsp/lsp.dart' show lspChannel, CompletionItem;
+import 'package:test/test.dart';
+
+void main() {
+  Stream<Peer> clients;
+  ServerSocket serverSocket;
+  Vim vim;
+  Peer client;
+
+  setUpAll(() async {
+    serverSocket = await ServerSocket.bind('localhost', 0);
+
+    clients = serverSocket.map((socket) {
+      return Peer(lspChannel(socket, socket), onUnhandledError: (error, stack) {
+        fail('Unhandled server error: $error');
+      });
+    }).asBroadcastStream();
+    vim = await Vim.start();
+    await vim.expr('RegisterLanguageServer("text", {'
+        '"command":"localhost:${serverSocket.port}",'
+        '"enabled":v:false,'
+        '})');
+  });
+
+  setUp(() async {
+    final nextClient = clients.first;
+    await vim.edit('foo.txt');
+    await vim.sendKeys(':LSClientEnable<cr>');
+    client = await nextClient;
+  });
+
+  tearDown(() async {
+    await vim.sendKeys(':LSClientDisable<cr>');
+    await vim.sendKeys(':%bwipeout!<cr>');
+    final file = File('foo.txt');
+    if (await file.exists()) await file.delete();
+    await client.done;
+    client = null;
+  });
+
+  tearDownAll(() async {
+    await vim.quit();
+    final log = File(vim.name);
+    print(await log.readAsString());
+    await log.delete();
+    await serverSocket.close();
+  });
+
+  test('autocomplete on trigger', () async {
+    client
+      ..registerLifecycleMethods({
+        'completionProvider': {
+          'triggerCharacters': ['.']
+        },
+      })
+      ..registerMethod('textDocument/didOpen', (_) {})
+      ..registerMethod('textDocument/didChange', (_) {})
+      ..registerMethod('textDocument/completion', (Parameters params) {
+        return [
+          CompletionItem((b) => b..label = 'abcd'),
+          CompletionItem((b) => b..label = 'foo')
+        ];
+      })
+      ..listen();
+    await vim.sendKeys('ifoo.');
+    await vim.waitForPopUpMenu();
+    await vim.sendKeys('a<c-n><esc><esc>');
+    expect(await vim.expr('getline(1)'), 'foo.abcd');
+  });
+
+  test('autocomplete on 3 word characters', () async {
+    client
+      ..registerLifecycleMethods({
+        'completionProvider': {'triggerCharacters': []},
+      })
+      ..registerMethod('textDocument/didOpen', (_) {})
+      ..registerMethod('textDocument/didChange', (_) {})
+      ..registerMethod('textDocument/completion', (Parameters params) {
+        return [
+          CompletionItem((b) => b..label = 'foobar'),
+          CompletionItem((b) => b..label = 'fooother')
+        ];
+      })
+      ..listen();
+    await vim.sendKeys('ifoo');
+    await vim.waitForPopUpMenu();
+    await vim.sendKeys('b<c-n><esc><esc>');
+    expect(await vim.expr('getline(1)'), 'foobar');
+  });
+
+  test('manual completion', () async {
+    client
+      ..registerLifecycleMethods({
+        'completionProvider': {'triggerCharacters': []},
+      })
+      ..registerMethod('textDocument/didOpen', (_) {})
+      ..registerMethod('textDocument/didChange', (_) {})
+      ..registerMethod('textDocument/completion', (Parameters params) {
+        return [
+          CompletionItem((b) => b..label = 'foobar'),
+          CompletionItem((b) => b..label = 'fooother')
+        ];
+      })
+      ..listen();
+    await vim.sendKeys('if<c-x><c-u>');
+    await vim.waitForPopUpMenu();
+    await vim.sendKeys('<c-n><esc><esc>');
+    expect(await vim.expr('getline(1)'), 'foobar');
+  });
+}
+
+extension PopUp on Vim {
+  Future<void> waitForPopUpMenu() async {
+    final until = DateTime.now().add(const Duration(seconds: 5));
+    while (await this.expr('pumvisible()') != '1') {
+      await Future.delayed(const Duration(milliseconds: 50));
+      if (DateTime.now().isAfter(until)) {
+        throw StateError('Pop up menu is not visible');
+      }
+    }
+  }
+}
+
+extension LSP on Peer {
+  void registerLifecycleMethods(Map<String, dynamic> capabilities) {
+    registerMethod('initialize', (_) {
+      return {'capabilities': capabilities};
+    });
+    registerMethod('initialized', (_) {});
+    registerMethod('shutdown', (_) {});
+    registerMethod('exit', (_) {
+      close();
+    });
+  }
+}

--- a/test/integration/test/vim_test.dart
+++ b/test/integration/test/vim_test.dart
@@ -1,4 +1,4 @@
-@Timeout(Duration(seconds: 30))
+@Skip('https://github.com/dart-lang/json_rpc_2/issues/55')
 
 import 'dart:io';
 


### PR DESCRIPTION
Partial fix for #291

A completion list can contain many more items than will be displayed if
many items are filled out due to not matching the already typed base
word. Any time spent performing translation from an LSP style completion
item to a vim style item is wasted for the words that aren't displayed.
Delay the conversion until after an item is known to not be filtered.

- Perform only the dict -> list normalization initially, and pass the
  list of LSP items to the next step of completion.
- Find the star of the completion using the LSP items.
- Pass the base string to `s:CompletionItems`, perform the filtering in
  same loop as the conversion. Skip any items which don't match the
  base.
- Split `s:CompletionItem` into `s:CompletionItemWord` which finds the
  text to insert, and optionally the snippet user data, and
  `s:FinishItem` which does the heavier normalization including
  documentation details.
- Add some smoke tests for autocomplete.