### PR TITLE
Update message text for new file

### DIFF
--- a/test/integration/test/stderr_test.dart
+++ b/test/integration/test/stderr_test.dart
@@ -44,7 +44,7 @@ void main() {
     }
     final messages = await vim.messages(2);
     expect(messages, [
-      '"foo.txt" [New file] --No lines in buffer--',
+      '"foo.txt" [New] --No lines in buffer--',
       '[lsc:Error] Failed to initialize server: some server'
     ]);
   });


### PR DESCRIPTION
A bug was fixed in vim in 722e505d1a55dfde5ab62241d10da91d2e10c3c1 which
changed the output here depending on whether `n` is in `shortmess`
setting.