### PR TITLE
Remove the extra_args handling in gateResult

### DIFF
--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -9,16 +9,16 @@ function! lsc#edit#findCodeActions(...) abort
   let params.context = {'diagnostics':
       \ lsc#diagnostics#forLine(lsc#file#fullPath(), line('.') - 1)}
   call lsc#server#userCall('textDocument/codeAction', params,
-      \ lsc#util#gateResult('CodeActions', function('<SID>SelectAction'),
-      \     v:null, [ActionFilter]))
+      \ lsc#util#gateResult('CodeActions',
+      \     function('<SID>SelectAction', [ActionFilter])))
 endfunction
 
-function! s:SelectAction(result, action_filter) abort
+function! s:SelectAction(ActionFilter, result) abort
   if type(a:result) != type([]) || len(a:result) == 0
     call lsc#message#show('No actions available')
     return
   endif
-  call a:action_filter(a:result, function('<SID>ExecuteCommand'))
+  call a:ActionFilter(a:result, function('<SID>ExecuteCommand'))
 endfunction
 
 function! s:ExecuteCommand(choice) abort

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -162,21 +162,10 @@ function! lsc#util#gateResult(name, callback, ...) abort
   else
     let OnSkip = v:false
   endif
-  if a:0 >= 2 && type(a:2) == type([])
-    let extra_args = a:2
-  else
-    let extra_args = []
-  endif
-  return function('<SID>Gated',
-      \ [a:name, gate, old_pos, a:callback, OnSkip, extra_args])
+  return function('<SID>Gated', [a:name, gate, old_pos, a:callback, OnSkip])
 endfunction
 
-function! s:Gated(name, gate, old_pos, on_call, on_skip, extra_args, ...) abort
-  if !empty('a:extra_args')
-    let args = extend(deepcopy(a:000), a:extra_args)
-  else
-    let args = a:000
-  endif
+function! s:Gated(name, gate, old_pos, on_call, on_skip, ...) abort
   if s:callback_gates[a:name] != a:gate ||
       \ a:old_pos != getcurpos()
     if type(a:on_skip) == type({_->_})

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -169,10 +169,10 @@ function! s:Gated(name, gate, old_pos, on_call, on_skip, ...) abort
   if s:callback_gates[a:name] != a:gate ||
       \ a:old_pos != getcurpos()
     if type(a:on_skip) == type({_->_})
-      call call(a:on_skip, args)
+      call call(a:on_skip, a:000)
     endif
   else
-    call call(a:on_call, args)
+    call call(a:on_call, a:000)
   endif
 endfunction
 


### PR DESCRIPTION
Binding arguments to funcrefs is already handled as a Partial, there
isn't a need to have a second mechanism to hold these arguments.

- Remove the check for further positional arguments in `gateResult`.
- Pass `ActionFilter` through the `function` call rather than through
  `gateResult`. Reorder the arguments to match.
- Rename the `ActionFilter` argument within `SelectAction` for
  consistency.