### PR TITLE
Improve handling of key mapping

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -22,7 +22,6 @@ endfunction
 " Run language servers for this filetype if they aren't already running and
 " flush file changes.
 function! lsc#file#onOpen() abort
-  call lsc#config#mapKeys()
   if &modifiable && expand('%') !~# '\vfugitive:///'
     call lsc#server#start(&filetype)
     call s:FlushChanges(lsc#file#fullPath(), &filetype)

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -87,6 +87,7 @@ function! s:Kill(server, status, OnExit) abort
       call a:server._channel.notify('exit', v:null)
     endif
     if a:OnExit != v:null | call a:OnExit() | endif
+    call lsc#config#unmapKeys()
   endfunction
   return a:server.request('shutdown', v:null, funcref('Exit'))
 endfunction

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -119,6 +119,7 @@ endfunction
 function! s:Start(server) abort
   if has_key(a:server, '_channel')
     " Server is already running
+    call lsc#config#mapKeys()
     return
   endif
   let l:command = a:server.config.command
@@ -145,6 +146,7 @@ function! s:Start(server) abort
     for filetype in a:server.filetypes
       call lsc#file#trackAll(filetype)
     endfor
+    call lsc#config#mapKeys()
   endfunction
   if exists('g:lsc_trace_level') &&
       \ index(['off', 'messages', 'verbose'], g:lsc_trace_level) >= 0

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -159,7 +159,6 @@ endfunction
 
 function! s:OnOpen() abort
   if !has_key(g:lsc_servers_by_filetype, &filetype) | return | endif
-  call lsc#config#mapKeys()
   if !lsc#server#filetypeActive(&filetype) | return | endif
   call lsc#file#onOpen()
 endfunction


### PR DESCRIPTION
* Only map keys when server is successfully initialized or is already running. This prevents the scenario where LSC still maps keys even if the server fails to initialize (in which case the key mappings are useless).

* Unmap keys when the server shuts down. Similar to point 1, if the user runs `:LSClientDisable` then the LSC mappings should be removed.