### PR TITLE
Unfold before edits

### DIFF
--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -142,6 +142,7 @@ function! s:ApplyAll(changes) abort
     else
       let l:cmd .= ' edit '.l:file_path
     endif
+    let l:cmd .= ' | silent execute "set fdl=99"'
     call sort(l:edits, '<SID>CompareEdits')
     for l:idx in range(0, len(l:edits) - 1)
       let l:cmd .= ' | silent execute "keepjumps normal! '


### PR DESCRIPTION
Noticed some of my rename symbol operations were mangling files -  looks like it's due to my having `foldlevelstart` set in vimrc.

If `foldlevelstart` is set edits can potentially replace the entire containing fold of the symbol when renaming, this change unfolds the file before applying the edits.