### PR TITLE
Add workspace/configuration handling

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -169,7 +169,8 @@ function! s:ClientCapabilities() abort
   return {
     \ 'workspace': {
     \   'applyEdit': applyEdit,
-    \   },
+    \   'configuration': v:true,
+    \ },
     \ 'textDocument': {
     \   'synchronization': {
     \     'willSave': v:false,
@@ -337,6 +338,16 @@ function! s:Dispatch(server, method, params, id) abort
     let l:applied = lsc#edit#apply(a:params.edit)
     let l:response = {'applied': l:applied}
     call a:server.respond(a:id, l:response)
+  elseif a:method ==? 'workspace/configuration'
+    " TODO: Properly handle the configuration request parameters.  For now we
+    " just assume that workspace_config is one for every scopeURI and every
+    " configuration section.
+    if has_key(a:server.config, 'workspace_config')
+      let l:response = [a:server.config.workspace_config]
+      call a:server.respond(a:id, l:response)
+    else
+      call a:server.respond(a:id, [])
+    endif
   elseif a:method =~? '\v^\$'
     call lsc#config#handleNotification(a:server, a:method, a:params)
   endif

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -361,7 +361,8 @@ function! s:Dispatch(server, method, params, id) abort
     let l:response = {'applied': l:applied}
     call a:server.respond(a:id, l:response)
   elseif a:method ==? 'workspace/configuration'
-    let l:response = map(a:params, {_, item -> a:server.find_config(item)})
+    let l:items = a:params.items
+    let l:response = map(l:items, {_, item -> a:server.find_config(item)})
     call a:server.respond(a:id, l:response)
   elseif a:method =~? '\v^\$'
     call lsc#config#handleNotification(a:server, a:method, a:params)

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -576,8 +576,9 @@ For example:
                                                 *lsc-server-workspace_config*
 `workspace_config`: Set to any json encodable value which will be sent to the
 server after startup as the `settings` in a `workspace/didChangeConfiguration`
-notificaiton. See the documentation for your server for what values are accepted
-in this notification.
+notification. See the documentation for your server for what values are accepted
+in this notification. The configuration here is also used to respond to
+`workspace/configuration` requests from the server. All `scopeUri` are ignored.
 
 For example:
 >

--- a/test/integration/lib/stub_lsp.dart
+++ b/test/integration/lib/stub_lsp.dart
@@ -11,6 +11,7 @@ extension LSP on Peer {
       return {'capabilities': capabilities};
     });
     registerMethod('initialized', (_) {});
+    registerMethod('workspace/didChangeConfiguration', (_) {});
     registerMethod('textDocument/didOpen', _cast(didOpen) ?? _ignore);
     registerMethod('textDocument/didChange', _cast(didChange) ?? _ignore);
     registerMethod('textDocument/didSave', _cast(didSave) ?? _ignore);

--- a/test/integration/test/workspace_configuration_test.dart
+++ b/test/integration/test/workspace_configuration_test.dart
@@ -56,7 +56,9 @@ void main() {
       ..registerLifecycleMethods({})
       ..listen();
 
-    final response = await client.sendRequest('workspace/configuration', [{}]);
+    final response = await client.sendRequest('workspace/configuration', {
+      'items': [{}]
+    });
     expect(response, [
       {
         'foo': {'baz': 'bar'},
@@ -70,10 +72,12 @@ void main() {
       ..registerLifecycleMethods({})
       ..listen();
 
-    final response = await client.sendRequest('workspace/configuration', [
-      {'section': 'foo'},
-      {'section': 'other'}
-    ]);
+    final response = await client.sendRequest('workspace/configuration', {
+      'items': [
+        {'section': 'foo'},
+        {'section': 'other'}
+      ]
+    });
     expect(response, [
       {'baz': 'bar'},
       'something'
@@ -85,9 +89,11 @@ void main() {
       ..registerLifecycleMethods({})
       ..listen();
 
-    final response = await client.sendRequest('workspace/configuration', [
-      {'section': 'foo.baz'},
-    ]);
+    final response = await client.sendRequest('workspace/configuration', {
+      'items': [
+        {'section': 'foo.baz'},
+      ]
+    });
     expect(response, ['bar']);
   });
 
@@ -96,10 +102,12 @@ void main() {
       ..registerLifecycleMethods({})
       ..listen();
 
-    final response = await client.sendRequest('workspace/configuration', [
-      {'section': 'foo.missing'},
-      {'section': 'missing'}
-    ]);
+    final response = await client.sendRequest('workspace/configuration', {
+      'items': [
+        {'section': 'foo.missing'},
+        {'section': 'missing'}
+      ]
+    });
     expect(response, [null, null]);
   });
 }

--- a/test/integration/test/workspace_configuration_test.dart
+++ b/test/integration/test/workspace_configuration_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:_test/stub_lsp.dart';
+import 'package:_test/vim_remote.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:lsp/lsp.dart' show lspChannel;
+import 'package:test/test.dart';
+
+void main() {
+  Stream<Peer> clients;
+  Vim vim;
+  Peer client;
+
+  setUpAll(() async {
+    final serverSocket = await ServerSocket.bind('localhost', 0);
+    addTearDown(serverSocket.close);
+
+    clients = serverSocket.map((socket) {
+      return Peer(lspChannel(socket, socket), onUnhandledError: (error, _) {
+        fail('Unhandled server error: $error');
+      });
+    }).asBroadcastStream();
+    vim = await Vim.start();
+    await vim.expr('RegisterLanguageServer("text", {'
+        '"command":"localhost:${serverSocket.port}",'
+        '"workspace_config":{"foo":{"baz":"bar"}},'
+        '"enabled":v:false,'
+        '})');
+  });
+
+  setUp(() async {
+    final nextClient = clients.first;
+    await vim.edit('foo.txt');
+    await vim.sendKeys(':LSClientEnable<cr>');
+    client = await nextClient;
+  });
+
+  tearDown(() async {
+    await vim.sendKeys(':LSClientDisable<cr>');
+    await vim.sendKeys(':%bwipeout!<cr>');
+    final file = File('foo.txt');
+    if (await file.exists()) await file.delete();
+    await client.done;
+    client = null;
+  });
+
+  tearDownAll(() async {
+    await vim.quit();
+    final log = File(vim.name);
+    print(await log.readAsString());
+    await log.delete();
+  });
+
+  test('can send workspace configuration', () async {
+    client
+      ..registerLifecycleMethods({})
+      ..listen();
+
+    final response = await client.sendRequest('workspace/configuration', [{}]);
+    expect(response, [
+      {
+        'foo': {'baz': 'bar'}
+      }
+    ]);
+  });
+}


### PR DESCRIPTION
After receiving workspace/didChangeConfiguration some servers will
request the full updated configuration from the client using
workspace/configuration instead of reading the changed configuration
section clients have sent them.  So, support this capability and respond
with a workspace configuration if there is one.

See also: golang/go#41311.