### PR TITLE
Reuse location lists instead of appending new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
 - Send `hover.contentFormat` to prefer plaintext content which should be more
   readable for most users.
 - Use full words for completion item kinds instead of single letters.
+- Avoid overwriting location list if it is in use for something other than LSC
+  diagnostics.
 
 # 0.3.2
 

--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -152,8 +152,9 @@ function! lsc#diagnostics#showLocationList() abort
   endif
   let l:list_id = gettabwinvar(0, l:window_id, 'lsc_location_list_id', -1)
   if !s:SurfaceLocationList(l:list_id)
-    let l:items = lsc#diagnostics#forFile(lsc#file#fullPath()).ListItems()
-    call s:CreateLocationList(win_getid(), l:items)
+    let l:path = lsc#file#normalize(bufname(winbufnr(l:window_id)))
+    let l:items = lsc#diagnostics#forFile(l:path).ListItems()
+    call s:CreateLocationList(l:window_id, l:items)
   endif
   lopen
 endfunction

--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -151,7 +151,7 @@ function! lsc#diagnostics#showLocationList() abort
     endif
   endif
   let l:list_id = gettabwinvar(0, l:window_id, 'lsc_location_list_id', -1)
-  if !s:SurfaceLocationList(l:list_id)
+  if l:list_id != -1 && !s:SurfaceLocationList(l:list_id)
     let l:path = lsc#file#normalize(bufname(winbufnr(l:window_id)))
     let l:items = lsc#diagnostics#forFile(l:path).ListItems()
     call s:CreateLocationList(l:window_id, l:items)
@@ -162,22 +162,19 @@ endfunction
 " If the LSC maintained location list exists in the location list stack, switch
 " to it and return true, otherwise return false.
 function! s:SurfaceLocationList(list_id) abort
-  if a:list_id != -1
-    let l:list_info = getloclist(0, {'nr': 0, 'id': a:list_id})
-    let l:nr = get(l:list_info, 'nr', -1)
-    if l:nr > 0
-      let l:diff = getloclist(0, {'nr': 0}).nr - l:nr
-      if l:diff == 0
-        " already there
-      elseif l:diff > 0
-        execute 'lolder '.string(l:diff)
-      else
-        execute 'lnewer '.string(abs(l:diff))
-      endif
-      return v:true
-    endif
+  let l:list_info = getloclist(0, {'nr': 0, 'id': a:list_id})
+  let l:nr = get(l:list_info, 'nr', -1)
+  if l:nr <= 0 | return v:false | endif
+
+  let l:diff = getloclist(0, {'nr': 0}).nr - l:nr
+  if l:diff == 0
+    " already there
+  elseif l:diff > 0
+    execute 'lolder '.string(l:diff)
+  else
+    execute 'lnewer '.string(abs(l:diff))
   endif
-  return v:false
+  return v:true
 endfunction
 
 " Returns the total number of diagnostics in all files.

--- a/autoload/lsc/highlights.vim
+++ b/autoload/lsc/highlights.vim
@@ -39,8 +39,8 @@ function! lsc#highlights#clear() abort
     endfor
   endif
   let w:lsc_diagnostic_matches = []
-  if exists('w:lsc_highlights_version')
-    unlet w:lsc_highlights_version
+  if exists('w:lsc_highlights_source')
+    unlet w:lsc_highlights_source
   endif
 endfunction
 
@@ -60,13 +60,11 @@ endfunction
 
 " Whether the diagnostic highlights for the current window are up to date.
 function! s:CurrentWindowIsFresh() abort
-  if !exists('w:lsc_diagnostics_version') | return v:true | endif
-  if !exists('w:lsc_highlights_version') | return v:false | endif
-  return w:lsc_highlights_version == w:lsc_diagnostics_version &&
-      \ w:lsc_highlights_file == w:lsc_diagnostics_file
+  if !exists('w:lsc_diagnostics') | return v:true | endif
+  if !exists('w:lsc_highlights_source') | return v:false | endif
+  return w:lsc_highlights_source is w:lsc_diagnostics
 endfunction
 
 function! s:MarkCurrentWindowFresh() abort
-  let w:lsc_highlights_version = w:lsc_diagnostics_version
-  let w:lsc_highlights_file = w:lsc_diagnostics_file
+  let w:lsc_highlight_source = w:lsc_diagnostics
 endfunction

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -294,8 +294,8 @@ The server may communicate diagnostics but they will be ignored. Changing this
 configuration while a server is running may have unexpected results, if it is
 changed use |:LSClientRestartServer|.
 
-If the locatio list is in use by a list other than the LSC diagnostics you won't
-see updates as diagnostics change. Call |:LSClientWindowDiagnostics| to
+If the location list is in use by a list other than the LSC diagnostics you
+won't see updates as diagnostics change. Call |:LSClientWindowDiagnostics| to
 restore the LSC diagnostics list.
 
                                                 *lsc-configure-hover*

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -152,12 +152,29 @@ With |lsc-default-map| this command is bount to "gR". This comand will not
 exist if |g:lsc_enable_apply_edit| is set to `v:false`.
 
                                                 *:LSClientAllDiagnostics*
-Popupate the quickfix list with all diagnostics that have been sent by the
+Populate the |quickfix| list with all diagnostics that have been sent by the
 server, spanning all files. Depending on the server implementation this may
 show all diagnostics for open files, or also diagnostics for files that have
 not yet been opened. After running this command the quickfix list will be
 updated any time diagnostics change, until the quickfix list is set by some
 other command.
+
+                                                *:LSClientWindowDiagnostics*
+By default vim-lsc will create a location list for every window with an LSC
+tracked buffer open. In the typical case |:lopen| is sufficient to see a
+continuously updated list of diagnostics for the current buffer.
+
+If the current location list for a window is in use for another list it will not
+be overwritten. The `:LSClientWindowDiagnostics` command will restore the LSC
+diagnostics to the location list.
+
+The LSC diagnostics list is always kept up to day as long as it still exists on
+the location list stack. Use |:lolder|, |:lnewer|, or |:lhistory| to switch
+between the LSC diagnostics list and other lists. If the LSC list leaves the
+stack because there are 10 other lists that replaced it, it can be restored on
+the top of the stack with `:LSClientWindowDiagnostics`. If the command is
+invoked while the list is still on the stack it will be chosen as the current
+list.
 
                                                 *:LSClientLineDiagnostics*
 Echo the full text of all diagnostics on the current line. Useful when a
@@ -276,6 +293,10 @@ diagnostics disabled |:LSClientAllDiagnostics| will never surface any results.
 The server may communicate diagnostics but they will be ignored. Changing this
 configuration while a server is running may have unexpected results, if it is
 changed use |:LSClientRestartServer|.
+
+If the locatio list is in use by a list other than the LSC diagnostics you won't
+see updates as diagnostics change. Call |:LSClientWindowDiagnostics| to
+restore the LSC diagnostics list.
 
                                                 *lsc-configure-hover*
                                                 *g:lsc_preview_split_direction*

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -36,6 +36,7 @@ command! -nargs=? LSClientWorkspaceSymbol
 command! -nargs=? LSClientFindCodeActions
     \ call lsc#edit#findCodeActions(lsc#edit#filterActions(<args>))
 command! LSClientAllDiagnostics call lsc#diagnostics#showInQuickFix()
+command! LSClientWindowDiagnostics call lsc#diagnostics#showLocationList()
 command! LSClientLineDiagnostics call lsc#diagnostics#echoForLine()
 command! LSClientSignatureHelp call lsc#signaturehelp#getSignatureHelp()
 command! LSClientRestartServer call <SID>IfEnabled('lsc#server#restart')
@@ -134,7 +135,7 @@ function! LSCEnsureCurrentWindowState() abort
     if exists('w:lsc_diagnostic_matches')
       call lsc#highlights#clear()
     endif
-    if exists('w:lsc_diagnostics_version')
+    if exists('w:lsc_diagnostics')
       call lsc#diagnostics#clear()
     endif
     if exists('w:lsc_reference_matches')
@@ -142,7 +143,7 @@ function! LSCEnsureCurrentWindowState() abort
     endif
     return
   endif
-  call lsc#diagnostics#updateLocationList(lsc#file#fullPath())
+  call lsc#diagnostics#updateCurrentWindow()
   call lsc#highlights#update()
   call lsc#cursor#onWinEnter()
 endfunction


### PR DESCRIPTION
Closes #339

Avoid stomping over location lists used for other purposes.

When there is no location list there is nothing that will be hidden so
it is safe to add a new one for diagnostics, including an empty list if
there are no diagnostics. If there is any existing location list, try
instead to update a previously written list which may either be shown or
hidden on the location list stack. If there was not previously a list
written, or if the previously written list has fallen off the end of the
location list stack, the call to `setloclist` will do nothing. In both
cases this is safe because it is not possible to return to the list or
see it in `:lhistory` so the stale list is never seen. Add a command
`:LSClientWindowDiagnostics` to either resurface an existing list or
write a new one.

- Replace diagnostic and highlight `_version` and `_file` variables with
  `lsc_diagnostics` and `lsc_highlights_source` variables. Use an
  identity check with `is` to avoid the need for multiple variables to
  form a unique ID. Removes the `s:diagnostic_versions` dictionary,
  related function, and updating code paths.
- Rename `updateLocationList` to `UpdateWindowStates` to make it clear
  that other window local state is changed, specifically the
  `w:lsc_diagnostics`  and possibly `w:lsc_location_list_id` variables.
- Split into separate `s:UpdateWindowStates` and `updateCurrentWindow`
  functions to improve clarity. Pull out a private `UpdateWindowState`
  for the shared logic. Split location list updating into more fine
  grained functions as well.
- When writing a new location list store the list ID into a window
  variable so that it can be updated later.
- Add a command `:LSClientWindowDiagnostics` which will either resurface
  a hidden LSC diagnostics list if it is somewhere in `:lhistory`, or
  create a new one. When invoked in a location list window which has a
  location list open associated with a real window, uses the LSC buffer
  associated with that window. This matches the behavior of commands
  like `:lhistory` which may be invoked in either window. Counts how far
  away the LSC diagnostics buffer is and uses `:lolder` or `:lnewer` to
  move there. `:<count>lhistory` does not work in nvim.
- Update docs.