### PR TITLE
Drop windowsForFile utility

### DIFF
--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -108,7 +108,7 @@ endfunction
 function! lsc#diagnostics#updateLocationList(file_path) abort
   if lsc#file#bufnr(a:file_path) == -1 | return | endif
   let diagnostics_version = s:DiagnosticsVersion(a:file_path)
-  for window_id in lsc#util#windowsForFile(a:file_path)
+  for window_id in win_findbuf(lsc#file#bufnr(a:file_path))
     if !s:WindowIsCurrent(window_id, a:file_path, diagnostics_version)
       if !exists('l:items')
         let items = lsc#diagnostics#forFile(a:file_path).ListItems()

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -30,15 +30,6 @@ function! s:Callback(group) abort
   unlet s:callbacks[a:group]
 endfunction
 
-" Returns the window IDs of the windows showing the buffer opened for
-" [file_path].
-function! lsc#util#windowsForFile(file_path) abort
-  let l:bufnr = lsc#file#bufnr(a:file_path)
-  if l:bufnr == -1 | return [] | endif
-  let bufinfo = getbufinfo(l:bufnr)
-  return copy(bufinfo[0].windows)
-endfunction
-
 " Compare two quickfix or location list items.
 "
 " Items are compared with priority order:


### PR DESCRIPTION
There is a built in for this with `win_findbuf()`. It still needs to use
`lsc#file#bufnr` but since this is only used on in place it can be
inlined.