### PR TITLE
Syntax highlight signature help preview (for #345)

### DIFF
--- a/autoload/lsc/signaturehelp.vim
+++ b/autoload/lsc/signaturehelp.vim
@@ -47,7 +47,7 @@ function! s:ShowHelp(signatureHelp) abort
   endif
 
   if !has_key(signature, 'parameters')
-    call lsc#util#displayAsPreview([signature.label], 'text',
+    call lsc#util#displayAsPreview([signature.label], &filetype,
         \ function('<SID>HighlightCurrentParameter'))
     return
   endif
@@ -60,7 +60,7 @@ function! s:ShowHelp(signatureHelp) abort
     endif
   endif
 
-  call lsc#util#displayAsPreview([signature.label], 'text',
+  call lsc#util#displayAsPreview([signature.label], &filetype,
       \ function('<SID>HighlightCurrentParameter'))
 
 endfunction


### PR DESCRIPTION
Currently invoking signature help results in a plain text preview window.

Instead it is more pleasant to view signatures using syntax highlighting. The filetype of the current buffer where the signature is being requested should transfer to the preview window (for example C++ or Dart or JavaScript).