### PR TITLE
Disable folds while making edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Normalize windows file path separators to create valid URIs.
 - Don't send `textDocument/didSave` notifications if the server does not
   advertise it as a capability.
+- Fix edits when there are folds in the buffer.
 
 **Minor breaking changes**
 - Server dictionaries no longer expose their full `init_results`, or their call

--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -142,12 +142,19 @@ function! s:ApplyAll(changes) abort
     else
       let l:cmd .= ' edit '.l:file_path
     endif
+    let l:foldenable = &foldenable
+    if l:foldenable
+      let l:cmd .= ' | set nofoldenable'
+    endif
     call sort(l:edits, '<SID>CompareEdits')
     for l:idx in range(0, len(l:edits) - 1)
       let l:cmd .= ' | silent execute "keepjumps normal! '
       let l:cmd .= s:Apply(l:edits[l:idx])
       let l:cmd .= '\<C-r>=l:edits['.string(l:idx).'].newText\<cr>"'
     endfor
+    if l:foldenable
+      let l:cmd .= ' | set foldenable'
+    endif
     execute l:cmd
     if !&hidden | update | endif
     call lsc#file#onChange(l:file_path)


### PR DESCRIPTION
If an edit is within or across a fold it won't work correctly while the
fold is closed. Disable folds while making edits and restore the setting
afterwards.