### PR TITLE
Add languageId to server config

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -66,7 +66,6 @@ function! s:DidOpen(file_path) abort
   let filetype = getbufvar(l:bufnr, '&filetype')
   let l:params = {'textDocument':
       \   {'uri': lsc#uri#documentUri(a:file_path),
-      \    'languageId': filetype,
       \    'version': 1,
       \    'text': join(buffer_content, "\n")
       \   }
@@ -74,6 +73,7 @@ function! s:DidOpen(file_path) abort
   " TODO handle multiple servers
   let l:success = v:false
   for l:server in lsc#server#forFileType(l:filetype)
+    let l:params.textDocument.languageId = l:server.languageId[l:filetype]
     let l:success = l:server.notify('textDocument/didOpen', l:params)
   endfor
   if l:success

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -221,6 +221,7 @@ function! lsc#server#enable() abort
 endfunction
 
 function! lsc#server#register(filetype, config) abort
+  let languageId = a:filetype
   if type(a:config) == type('')
     let config = {'command': a:config, 'name': a:config}
   elseif type(a:config) == type([])
@@ -236,10 +237,14 @@ function! lsc#server#register(filetype, config) abort
     if !has_key(config, 'name')
       let config.name = string(config.command)
     endif
+    if has_key(config, 'languageId')
+      let languageId = config.languageId
+    endif
   endif
   let g:lsc_servers_by_filetype[a:filetype] = config.name
   if has_key(s:servers, config.name)
     call add(s:servers[config.name].filetypes, a:filetype)
+    let s:servers[config.name].languageId[a:filetype] = languageId
     return
   endif
   let initial_status = 'not started'
@@ -250,9 +255,11 @@ function! lsc#server#register(filetype, config) abort
       \ 'status': initial_status,
       \ 'logs': [],
       \ 'filetypes': [a:filetype],
+      \ 'languageId': {},
       \ 'config': config,
       \ 'capabilities': lsc#capabilities#defaults()
       \}
+  let server.languageId[a:filetype] = languageId
   function! server.request(method, params, callback) abort
     if self.status !=# 'running' | return v:false | endif
     let l:params = lsc#config#messageHook(self, a:method, a:params)

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -466,6 +466,11 @@ are configured with the same name use the same server.
 `'enabled'`: Set to `v:false` to avoid starting the server until
 |:LSClientEnable| is called.
 
+                                                *lsc-server-languageId*
+`'languageId'`: Defaults to `&filetype`. Change if your server expects a
+languageId that is not the current filetype.
+Use this if you use a subfiletype like `framework.language`.
+
                                                 *lsc-server-log_level*
 `'log_level'`: May be one of `'Error'`, `'Warning'`, `'Info'`, or `'Log'`.
 Default `'Info'`. Messages through `window/logMessage` will only be echoed


### PR DESCRIPTION
Some `&filetype`s may not match the `languageId` expected from the language server.
The server config can now contain a languageId which will be used instead of the filetype.

Closes #350