### PR TITLE
Go to last char if position is beyond last line

### DIFF
--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -191,6 +191,13 @@ endfunction
 
 " Find the normal mode commands to go to [pos]
 function! s:GoToChar(pos) abort
+  " In case the position is beyond the end of the buffer, we assume the range
+  " goes till the end of the buffer. We change pos to last line/last
+  " character.
+  if a:pos.line > line("$") - 1
+    let a:pos.line = line("$") - 1
+    let a:pos.character = strchars(getline("$"))
+  endif
   let l:cmd = ''
   let l:cmd .= printf('%dG', a:pos.line + 1)
   if a:pos.character == 0

--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -194,9 +194,9 @@ function! s:GoToChar(pos) abort
   " In case the position is beyond the end of the buffer, we assume the range
   " goes till the end of the buffer. We change pos to last line/last
   " character.
-  if a:pos.line > line("$") - 1
-    let a:pos.line = line("$") - 1
-    let a:pos.character = strchars(getline("$"))
+  if a:pos.line > line('$') - 1
+    let a:pos.line = line('$') - 1
+    let a:pos.character = strchars(getline('$'))
   endif
   let l:cmd = ''
   let l:cmd .= printf('%dG', a:pos.line + 1)


### PR DESCRIPTION
Specifically with pyls, if you do a rename, the server seems to return the whole file as a change. Therefore the change starts at position 0/0 (line/character) and ends at last line +1 / 0 (the first character on the line behind the last line of the buffer). This position can't be reached with the cursor.
I added a test for pos beyond last line and modify the position to go to the last character of the last line.
The rename in pyls works this way as expected.
This hopefully fixes #317 