### PR TITLE
Add trailing newlines to buffer content

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -67,7 +67,7 @@ function! s:DidOpen(file_path) abort
   let l:params = {'textDocument':
       \   {'uri': lsc#uri#documentUri(a:file_path),
       \    'version': 1,
-      \    'text': join(buffer_content, "\n")
+      \    'text': join(buffer_content, "\n")."\n"
       \   }
       \ }
   " TODO handle multiple servers
@@ -139,7 +139,7 @@ function! s:FlushChanges(file_path, filetype) abort
   if allow_incremental
     let change = lsc#diff#compute(s:file_content[a:file_path], buffer_content)
   else
-    let change = {'text': join(buffer_content, "\n")}
+    let change = {'text': join(buffer_content, "\n")."\n"}
   endif
   let l:params = {'textDocument':
       \   {'uri': lsc#uri#documentUri(a:file_path),


### PR DESCRIPTION
Closes #318

Improves compatibility with some language servers and prevents
diagnostics from appearing for missing newlines.

This is not a full solution, in some cases there really won't be a
trailing newline. Those cases should be rare, and including the newline
always should be an improvement for the vast majority of uses. A more
complete solution would check the settings to see if a trailing newline
would be written, but that appears to retain the server compatibility
issue, or reveal a bug in the diff computation.

```viml
function! s:eof(bufnr) abort
  let l:has_eol = getbufvar(a:bufnr, '&eol') ||
      \ (getbufvar(a:bufnr, '&fixeol') && !getbufvar(a:bufnr, '&binary'))
  return l:has_eol ? "\n" : ''
endfunction
```