### PR TITLE
Use a shared extension for LSP boilerplate

### DIFF
--- a/test/integration/bin/mock_server.dart
+++ b/test/integration/bin/mock_server.dart
@@ -1,7 +1,0 @@
-import 'package:_test/mock_lsp.dart';
-import 'package:lsp/lsp.dart';
-
-void main() async {
-  final server = await StdIOLanguageServer.start(MockLanguageServer());
-  await server.onDone;
-}

--- a/test/integration/bin/stub_server.dart
+++ b/test/integration/bin/stub_server.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+import 'package:_test/stub_lsp.dart';
+import 'package:lsp/lsp.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+
+void main() async {
+  final server = Peer(lspChannel(stdin, stdout))
+    ..registerLifecycleMethods({})
+    ..listen();
+  await server.done;
+}

--- a/test/integration/lib/mock_lsp.dart
+++ b/test/integration/lib/mock_lsp.dart
@@ -1,3 +1,0 @@
-import 'package:lsp/lsp.dart';
-
-class MockLanguageServer extends LanguageServer {}

--- a/test/integration/lib/stub_lsp.dart
+++ b/test/integration/lib/stub_lsp.dart
@@ -1,0 +1,27 @@
+import 'package:json_rpc_2/json_rpc_2.dart';
+
+extension LSP on Peer {
+  void registerLifecycleMethods(
+    Map<String, dynamic> capabilities, {
+    void Function(Parameters) didOpen,
+    void Function(Parameters) didChange,
+    void Function(Parameters) didSave,
+  }) {
+    registerMethod('initialize', (_) {
+      return {'capabilities': capabilities};
+    });
+    registerMethod('initialized', (_) {});
+    registerMethod('textDocument/didOpen', _cast(didOpen) ?? _ignore);
+    registerMethod('textDocument/didChange', _cast(didChange) ?? _ignore);
+    registerMethod('textDocument/didSave', _cast(didSave) ?? _ignore);
+    registerMethod('shutdown', (_) {});
+    registerMethod('exit', (_) {
+      close();
+    });
+  }
+}
+
+void Function(dynamic) _cast(void Function(Parameters) f) =>
+    f == null ? null : (p) => f(p as Parameters);
+
+void _ignore(dynamic _) {}

--- a/test/integration/test/complete_test.dart
+++ b/test/integration/test/complete_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:_test/stub_lsp.dart';
 import 'package:_test/vim_remote.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:lsp/lsp.dart' show lspChannel, CompletionItem;
@@ -58,8 +59,6 @@ void main() {
           'triggerCharacters': ['.']
         },
       })
-      ..registerMethod('textDocument/didOpen', (_) {})
-      ..registerMethod('textDocument/didChange', (_) {})
       ..registerMethod('textDocument/completion', (Parameters params) {
         return [
           CompletionItem((b) => b..label = 'abcd'),
@@ -78,8 +77,6 @@ void main() {
       ..registerLifecycleMethods({
         'completionProvider': {'triggerCharacters': []},
       })
-      ..registerMethod('textDocument/didOpen', (_) {})
-      ..registerMethod('textDocument/didChange', (_) {})
       ..registerMethod('textDocument/completion', (Parameters params) {
         return [
           CompletionItem((b) => b..label = 'foobar'),
@@ -98,8 +95,6 @@ void main() {
       ..registerLifecycleMethods({
         'completionProvider': {'triggerCharacters': []},
       })
-      ..registerMethod('textDocument/didOpen', (_) {})
-      ..registerMethod('textDocument/didChange', (_) {})
       ..registerMethod('textDocument/completion', (Parameters params) {
         return [
           CompletionItem((b) => b..label = 'foobar'),
@@ -123,18 +118,5 @@ extension PopUp on Vim {
         throw StateError('Pop up menu is not visible');
       }
     }
-  }
-}
-
-extension LSP on Peer {
-  void registerLifecycleMethods(Map<String, dynamic> capabilities) {
-    registerMethod('initialize', (_) {
-      return {'capabilities': capabilities};
-    });
-    registerMethod('initialized', (_) {});
-    registerMethod('shutdown', (_) {});
-    registerMethod('exit', (_) {
-      close();
-    });
   }
 }

--- a/test/integration/test/did_save_test.dart
+++ b/test/integration/test/did_save_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:_test/stub_lsp.dart';
 import 'package:_test/vim_remote.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:lsp/lsp.dart' show lspChannel;
@@ -59,13 +60,10 @@ void main() {
       });
     final didChange = Completer<Parameters>();
     client
-      ..registerLifecycleMethods(capabilities)
-      ..registerMethod(
-          'textDocument/didOpen', (params) => didOpen.complete(params))
-      ..registerMethod(
-          'textDocument/didSave', (params) => didSave.complete(params))
-      ..registerMethod(
-          'textDocument/didChange', (params) => didChange.complete(params))
+      ..registerLifecycleMethods(capabilities,
+          didOpen: didOpen.complete,
+          didChange: didChange.complete,
+          didSave: didSave.complete)
       ..listen();
 
     await didOpen.future;
@@ -92,11 +90,7 @@ void main() {
     client
       ..registerLifecycleMethods({
         'textDocumentSync': {'openClose': true, 'save': {}}
-      })
-      ..registerMethod(
-          'textDocument/didOpen', (params) => didOpen.complete(params))
-      ..registerMethod(
-          'textDocument/didSave', (params) => didSave.complete(params))
+      }, didOpen: didOpen.complete, didSave: didSave.complete)
       ..listen();
 
     await didOpen.future;
@@ -105,17 +99,4 @@ void main() {
 
     await didSave.future;
   });
-}
-
-extension LSP on Peer {
-  void registerLifecycleMethods(Map<String, dynamic> capabilities) {
-    registerMethod('initialize', (params) {
-      return {'capabilities': capabilities};
-    });
-    registerMethod('initialized', (_) {});
-    registerMethod('shutdown', (_) {});
-    registerMethod('exit', (_) {
-      close();
-    });
-  }
 }

--- a/test/integration/test/edit_test.dart
+++ b/test/integration/test/edit_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:_test/stub_lsp.dart';
 import 'package:_test/vim_remote.dart';
 import 'package:test/test.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
@@ -81,19 +82,4 @@ void main() {
     await Future.delayed(const Duration(milliseconds: 100));
     expect(await vim.expr(r'getline(1, "$")'), 'bar\nbar\n');
   });
-}
-
-extension LSP on Peer {
-  void registerLifecycleMethods(Map<String, dynamic> capabilities) {
-    registerMethod('initialize', (_) {
-      return {'capabilities': capabilities};
-    });
-    registerMethod('initialized', (_) {});
-    registerMethod('textDocument/didOpen', (_) {});
-    registerMethod('textDocument/didChange', (_) {});
-    registerMethod('shutdown', (_) {});
-    registerMethod('exit', (_) {
-      close();
-    });
-  }
 }

--- a/test/integration/test/vim_test.dart
+++ b/test/integration/test/vim_test.dart
@@ -9,7 +9,7 @@ void main() {
     Vim vim;
     setUpAll(() async {
       vim = await Vim.start();
-      final serverPath = p.absolute('bin', 'mock_server.dart');
+      final serverPath = p.absolute('bin', 'stub_server.dart');
       await vim.expr('RegisterLanguageServer("text","dart $serverPath")');
     });
 


### PR DESCRIPTION
Handling the `Peer` directly within tests has gone a little smoother
than going through the `LanguageServer` interface. Pull out a shared
extension method to add the lifecycle methods that are required for
most or all tests. Add optional named arguments to override the defaults
for file lifecycle methods.

Replace the `MockLanguageServer`, which was never used as a mock, with
the same approach used in the tests.