### PR TITLE
Add showcmd width to message truncate calculation

### DIFF
--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -25,7 +25,7 @@ function! lsc#cursor#showDiagnostic() abort
   let l:diagnostic = lsc#diagnostics#underCursor()
   if has_key(l:diagnostic, 'message')
     let l:max_width = &columns
-    let l:max_width -= 19 " Default ruler width (18) plus 1 character buffer
+    let l:max_width -= 29 " Default ruler width (18) plus showcmd width (10) plus 1 character buffer
     let l:message = strtrans(l:diagnostic.message)
     if strdisplaywidth(l:message) > l:max_width
       let l:max_width -= 3 " 3 chars for '...'

--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -24,8 +24,11 @@ endfunction
 function! lsc#cursor#showDiagnostic() abort
   let l:diagnostic = lsc#diagnostics#underCursor()
   if has_key(l:diagnostic, 'message')
-    let l:max_width = &columns
-    let l:max_width -= 29 " Default ruler width (18) plus showcmd width (10) plus 1 character buffer
+    let l:max_width = &columns - 1 " Avoid edge of terminal
+    let l:has_ruler = &ruler &&
+        \ (&laststatus == 0 || (&laststatus == 1 && winnr('$') < 2))
+    if l:has_ruler | let l:max_width -= 18 | endif
+    if &showcmd | let l:max_width -= 11 | endif
     let l:message = strtrans(l:diagnostic.message)
     if strdisplaywidth(l:message) > l:max_width
       let l:max_width -= 3 " 3 chars for '...'


### PR DESCRIPTION
I'm getting "Press Enter ..." prompts with long diagnostic messages. It turns out the current calculation takes into account `set ruler` but not `set showcmd`.

(I know I should probably start using `set laststatus=2` like normal people)

cc #204 