### PR TITLE
Make the server stub a real class

### DIFF
--- a/test/integration/bin/stub_server.dart
+++ b/test/integration/bin/stub_server.dart
@@ -5,8 +5,7 @@ import 'package:lsp/lsp.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 
 void main() async {
-  final server = Peer(lspChannel(stdin, stdout))
-    ..registerLifecycleMethods({})
-    ..listen();
-  await server.done;
+  final server = StubServer(Peer(lspChannel(stdin, stdout)));
+  await server.initialized;
+  await server.peer.done;
 }

--- a/test/integration/lib/stub_lsp.dart
+++ b/test/integration/lib/stub_lsp.dart
@@ -1,27 +1,40 @@
+import 'dart:async';
+
 import 'package:json_rpc_2/json_rpc_2.dart';
 
-extension LSP on Peer {
-  void registerLifecycleMethods(
-    Map<String, dynamic> capabilities, {
-    void Function(Parameters) didOpen,
-    void Function(Parameters) didChange,
-    void Function(Parameters) didSave,
-  }) {
-    registerMethod('initialize', (_) {
-      return {'capabilities': capabilities};
-    });
-    registerMethod('initialized', (_) {});
-    registerMethod('textDocument/didOpen', _cast(didOpen) ?? _ignore);
-    registerMethod('textDocument/didChange', _cast(didChange) ?? _ignore);
-    registerMethod('textDocument/didSave', _cast(didSave) ?? _ignore);
-    registerMethod('shutdown', (_) {});
-    registerMethod('exit', (_) {
-      close();
-    });
+class StubServer {
+  final Peer peer;
+
+  StubServer(this.peer, {Map<String, dynamic> capabilities = const {}}) {
+    peer
+      ..registerMethod('initialize', (_) {
+        return {'capabilities': capabilities};
+      })
+      ..registerMethod('initialized', (_) {
+        _initialized.complete();
+      })
+      ..registerMethod('workspace/didChangeConfiguration', (_) {})
+      ..registerMethod('textDocument/didOpen', _didOpen.add)
+      ..registerMethod('textDocument/didChange', _didChange.add)
+      ..registerMethod('textDocument/didSave', _didSave.add)
+      ..registerMethod('shutdown', (_) {})
+      ..registerMethod('exit', (_) {
+        peer.close();
+      });
   }
+  Stream<Parameters> get didOpen => _didOpen.stream;
+  final _didOpen = StreamController<Parameters>();
+
+  Stream<Parameters> get didChange => _didChange.stream;
+  final _didChange = StreamController<Parameters>();
+
+  Stream<Parameters> get didSave => _didSave.stream;
+  final _didSave = StreamController<Parameters>();
+
+  Future<void> get initialized {
+    peer.listen();
+    return _initialized.future;
+  }
+
+  final _initialized = Completer<void>();
 }
-
-void Function(dynamic) _cast(void Function(Parameters) f) =>
-    f == null ? null : (p) => f(p as Parameters);
-
-void _ignore(dynamic _) {}

--- a/test/integration/test/complete_test.dart
+++ b/test/integration/test/complete_test.dart
@@ -53,19 +53,18 @@ void main() {
   });
 
   test('autocomplete on trigger', () async {
-    client
-      ..registerLifecycleMethods({
-        'completionProvider': {
-          'triggerCharacters': ['.']
-        },
-      })
-      ..registerMethod('textDocument/completion', (Parameters params) {
-        return [
-          CompletionItem((b) => b..label = 'abcd'),
-          CompletionItem((b) => b..label = 'foo')
-        ];
-      })
-      ..listen();
+    final server = StubServer(client, capabilities: {
+      'completionProvider': {
+        'triggerCharacters': ['.']
+      },
+    });
+    server.peer.registerMethod('textDocument/completion', (Parameters params) {
+      return [
+        CompletionItem((b) => b..label = 'abcd'),
+        CompletionItem((b) => b..label = 'foo')
+      ];
+    });
+    await server.initialized;
     await vim.sendKeys('ifoo.');
     await vim.waitForPopUpMenu();
     await vim.sendKeys('a<c-n><esc><esc>');
@@ -73,17 +72,16 @@ void main() {
   });
 
   test('autocomplete on 3 word characters', () async {
-    client
-      ..registerLifecycleMethods({
-        'completionProvider': {'triggerCharacters': []},
-      })
-      ..registerMethod('textDocument/completion', (Parameters params) {
-        return [
-          CompletionItem((b) => b..label = 'foobar'),
-          CompletionItem((b) => b..label = 'fooother')
-        ];
-      })
-      ..listen();
+    final server = StubServer(client, capabilities: {
+      'completionProvider': {'triggerCharacters': []},
+    });
+    server.peer.registerMethod('textDocument/completion', (Parameters params) {
+      return [
+        CompletionItem((b) => b..label = 'foobar'),
+        CompletionItem((b) => b..label = 'fooother')
+      ];
+    });
+    await server.initialized;
     await vim.sendKeys('ifoo');
     await vim.waitForPopUpMenu();
     await vim.sendKeys('b<c-n><esc><esc>');
@@ -91,17 +89,16 @@ void main() {
   });
 
   test('manual completion', () async {
-    client
-      ..registerLifecycleMethods({
-        'completionProvider': {'triggerCharacters': []},
-      })
-      ..registerMethod('textDocument/completion', (Parameters params) {
-        return [
-          CompletionItem((b) => b..label = 'foobar'),
-          CompletionItem((b) => b..label = 'fooother')
-        ];
-      })
-      ..listen();
+    final server = StubServer(client, capabilities: {
+      'completionProvider': {'triggerCharacters': []},
+    });
+    server.peer.registerMethod('textDocument/completion', (Parameters params) {
+      return [
+        CompletionItem((b) => b..label = 'foobar'),
+        CompletionItem((b) => b..label = 'fooother')
+      ];
+    });
+    await server.initialized;
     await vim.sendKeys('if<c-x><c-u>');
     await vim.waitForPopUpMenu();
     await vim.sendKeys('<c-n><esc><esc>');

--- a/test/integration/test/edit_test.dart
+++ b/test/integration/test/edit_test.dart
@@ -55,27 +55,26 @@ void main() {
 
   test('edit of entire file', () async {
     final renameDone = Completer<void>();
-    client
-      ..registerLifecycleMethods({})
-      ..registerMethod('textDocument/rename', (Parameters params) {
-        renameDone.complete();
-        final uri = params['textDocument']['uri'].asString;
-        return WorkspaceEdit((b) => b
-          ..changes = {
-            uri: [
-              TextEdit((b) => b
-                ..newText = 'bar\nbar\n'
-                ..range = Range((b) => b
-                  ..start = Position((b) => b
-                    ..line = 0
-                    ..character = 0)
-                  ..end = Position((b) => b
-                    ..line = 2
-                    ..character = 0)))
-            ]
-          });
-      })
-      ..listen();
+    final server = StubServer(client);
+    server.peer.registerMethod('textDocument/rename', (Parameters params) {
+      renameDone.complete();
+      final uri = params['textDocument']['uri'].asString;
+      return WorkspaceEdit((b) => b
+        ..changes = {
+          uri: [
+            TextEdit((b) => b
+              ..newText = 'bar\nbar\n'
+              ..range = Range((b) => b
+                ..start = Position((b) => b
+                  ..line = 0
+                  ..character = 0)
+                ..end = Position((b) => b
+                  ..line = 2
+                  ..character = 0)))
+          ]
+        });
+    });
+    await server.initialized;
     await vim.sendKeys('ifoo<cr>foo<esc>');
     await vim.sendKeys(':LSClientRename \'bar\'<cr>');
     await renameDone;


### PR DESCRIPTION
Allows adding the `initialized` getter to wait for the vim client to
become initialized before further interactions. In some tests this can
prevent sending a request too early, and in some cases prevents moving
on to calling `LSClientDisable` before the server has been initialized,
which causes the client to not call `shutdown` and `exit`. Don't
`listen` on the peer until waiting for the `initialized` getter.