### PR TITLE
Use a regex to check vim message

### DIFF
--- a/test/integration/test/stderr_test.dart
+++ b/test/integration/test/stderr_test.dart
@@ -45,7 +45,7 @@ void main() {
     }
     final messages = await vim.messages(2);
     expect(messages, [
-      '"foo.txt" [New] --No lines in buffer--',
+      matches('"foo.txt" .* --No lines in buffer--'),
       '[lsc:Error] Failed to initialize server "some server". '
           'Failing command is: [\'sh\', \'-c\', \'echo messagestderr >&2\']'
     ]);


### PR DESCRIPTION
The exact message format seems to vary based on versions of vim, or
possibly flakily based on prior interactions. In either case, check the
message against a regex rather than an exact full match to allow some
variation which does not impact the intent of the test.