### PR TITLE
Enforce explicit variable scopes

### DIFF
--- a/.vintrc.yml
+++ b/.vintrc.yml
@@ -1,3 +1,6 @@
 cmdargs:
   severity: style_problem
   color: true
+policies:
+  ProhibitImplicitScopeVariable:
+    enabled: true

--- a/after/plugin/lsc.vim
+++ b/after/plugin/lsc.vim
@@ -3,6 +3,6 @@ let g:lsc_registered_commands = 1
 
 if !exists('g:lsc_server_commands') | finish | endif
 
-for [filetype, config] in items(g:lsc_server_commands)
-  call RegisterLanguageServer(filetype, config)
+for [l:filetype, l:config] in items(g:lsc_server_commands)
+  call RegisterLanguageServer(l:filetype, l:config)
 endfor

--- a/autoload/lsc/channel.vim
+++ b/autoload/lsc/channel.vim
@@ -47,19 +47,19 @@ function! s:Channel() abort
   let l:c = {'send_buffer': ''}
 
   function! l:c.send(message) abort
-    let self.send_buffer .= a:message
-    call self.__flush()
+    let l:self.send_buffer .= a:message
+    call l:self.__flush()
   endfunction
 
   function! l:c.__flush(...) abort
-    if len(self.send_buffer) <= 1024
-      call self._send(self.send_buffer)
-      let self.send_buffer = ''
+    if len(l:self.send_buffer) <= 1024
+      call l:self._send(l:self.send_buffer)
+      let l:self.send_buffer = ''
     else
-      let l:to_send = self.send_buffer[:1023]
-      let self.send_buffer = self.send_buffer[1024:]
-      call self._send(l:to_send)
-      call timer_start(0, self.__flush)
+      let l:to_send = l:self.send_buffer[:1023]
+      let l:self.send_buffer = l:self.send_buffer[1024:]
+      call l:self._send(l:to_send)
+      call timer_start(0, l:self.__flush)
     endif
   endfunction
 
@@ -69,13 +69,13 @@ endfunction
 function! s:WrapVim(vim_channel, c) abort
   let a:c._channel = a:vim_channel
   function! a:c._send(data) abort
-    call ch_sendraw(self._channel, a:data)
+    call ch_sendraw(l:self._channel, a:data)
   endfunction
 endfunction
 
 function! s:WrapNeovim(nvim_job, c) abort
   let a:c['_job'] = a:nvim_job
   function! a:c._send(data) abort
-    call jobsend(self._job, a:data)
+    call jobsend(l:self._job, a:data)
   endfunction
 endfunction

--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -33,9 +33,9 @@ endif
 
 " Clean state associated with a server.
 function! lsc#complete#clean(filetype) abort
-  for buffer in getbufinfo({'bufloaded': v:true})
-    if getbufvar(buffer.bufnr, '&filetype') != a:filetype | continue | endif
-    call setbufvar(buffer.bufnr, 'lsc_is_completing', v:false)
+  for l:buffer in getbufinfo({'bufloaded': v:true})
+    if getbufvar(l:buffer.bufnr, '&filetype') != a:filetype | continue | endif
+    call setbufvar(l:buffer.bufnr, 'lsc_is_completing', v:false)
   endfor
 endfunction
 
@@ -68,8 +68,8 @@ function! s:isCompletable() abort
       \ g:lsc_autocomplete_length : 3
   if l:min_length == v:false | return v:false | endif
   if l:cur_col < (l:min_length + 1) | return v:false | endif
-  let word = getline('.')[l:cur_col - (l:min_length + 1):l:cur_col - 2]
-  return word =~# '^\w*$'
+  let l:word = getline('.')[l:cur_col - (l:min_length + 1):l:cur_col - 2]
+  return l:word =~# '^\w*$'
 endfunction
 
 function! s:startCompletion(isAuto) abort
@@ -109,14 +109,14 @@ function! s:SuggestCompletions(items) abort
   endif
   let l:start = s:FindStart(a:items)
   let l:base = l:start != col('.')
-      \ ? getline('.')[start - 1:col('.') - 2]
+      \ ? getline('.')[l:start - 1:col('.') - 2]
       \ : ''
   let l:completion_items = s:CompletionItems(l:base, a:items)
   call s:SetCompleteOpt()
   if exists('#User#LSCAutocomplete')
     doautocmd <nomodeline> User LSCAutocomplete
   endif
-  call complete(start, l:completion_items)
+  call complete(l:start, l:completion_items)
 endfunction
 
 function! s:SetCompleteOpt() abort
@@ -169,14 +169,14 @@ endfunction
 " Finds the 1-based index of the character after the last non word character
 " behind the cursor.
 function! s:GuessCompletionStart() abort
-  let search = col('.') - 2
-  let line = getline('.')
-  while search > 0
-    let char = line[search]
-    if char !~# '\w'
-      return search + 2
+  let l:search = col('.') - 2
+  let l:line = getline('.')
+  while l:search > 0
+    let l:char = l:line[l:search]
+    if l:char !~# '\w'
+      return l:search + 2
     endif
-    let search -= 1
+    let l:search -= 1
   endwhile
   return 1
 endfunction
@@ -255,23 +255,24 @@ function! s:FinishItem(lsp_item, vim_item) abort
     let a:vim_item.kind = s:CompletionItemKind(a:lsp_item.kind)
   endif
   if has_key(a:lsp_item, 'detail') && a:lsp_item.detail != v:null
-    let detail_lines = split(a:lsp_item.detail, "\n")
-    if len(detail_lines) > 0
-      let a:vim_item.menu = detail_lines[0]
+    let l:detail_lines = split(a:lsp_item.detail, "\n")
+    if len(l:detail_lines) > 0
+      let a:vim_item.menu = l:detail_lines[0]
       let a:vim_item.info = a:lsp_item.detail
     endif
   endif
   if has_key(a:lsp_item, 'documentation')
-    let documentation = a:lsp_item.documentation
+    let l:documentation = a:lsp_item.documentation
     if has_key(a:vim_item, 'info')
       let a:vim_item.info .= "\n\n"
     else
       let a:vim_item.info = ''
     endif
-    if type(documentation) == type('')
-      let a:vim_item.info .= documentation
-    elseif type(documentation) == type({}) && has_key(documentation, 'value')
-      let a:vim_item.info .= documentation.value
+    if type(l:documentation) == type('')
+      let a:vim_item.info .= l:documentation
+    elseif type(l:documentation) == type({})
+        \ && has_key(l:documentation, 'value')
+      let a:vim_item.info .= l:documentation.value
     endif
   endif
 endfunction

--- a/autoload/lsc/config.vim
+++ b/autoload/lsc/config.vim
@@ -51,7 +51,7 @@ function! lsc#config#mapKeys() abort
     return
   endif
 
-  for command in [
+  for l:command in [
       \ 'GoToDefinition',
       \ 'GoToDefinitionSplit',
       \ 'FindReferences',
@@ -64,12 +64,12 @@ function! lsc#config#mapKeys() abort
       \ 'WorkspaceSymbol',
       \ 'SignatureHelp',
       \] + (get(g:, 'lsc_enable_apply_edit', 1) ? ['Rename'] : [])
-    let lhs = get(l:maps, command, [])
-    if type(lhs) != type('') && type(lhs) != type([])
+    let l:lhs = get(l:maps, l:command, [])
+    if type(l:lhs) != type('') && type(l:lhs) != type([])
       continue
     endif
-    for m in type(lhs) == type([]) ? lhs : [lhs]
-      execute 'nnoremap <buffer>'.m.' :LSClient'.command.'<CR>'
+    for l:m in type(l:lhs) == type([]) ? l:lhs : [l:lhs]
+      execute 'nnoremap <buffer>'.l:m.' :LSClient'.l:command.'<CR>'
     endfor
   endfor
   if has_key(l:maps, 'Completion') &&
@@ -99,9 +99,9 @@ endfunction
 
 function! lsc#config#messageHook(server, method, params) abort
   if !has_key(a:server.config, 'message_hooks') | return a:params | endif
-  let hooks = a:server.config.message_hooks
-  if !has_key(hooks, a:method) | return a:params | endif
-  let l:Hook = hooks[a:method]
+  let l:hooks = a:server.config.message_hooks
+  if !has_key(l:hooks, a:method) | return a:params | endif
+  let l:Hook = l:hooks[a:method]
   if type(l:Hook) == type({_->_})
     return s:RunHookFunction(l:Hook, a:method, a:params)
   elseif type(l:Hook) == type({})
@@ -124,9 +124,9 @@ function! s:RunHookFunction(Hook, method, params) abort
 endfunction
 
 function! s:MergeHookDict(hook, method, params) abort
-  let resolved = s:ResolveHookDict(a:hook, a:method, a:params)
-  for key in keys(resolved)
-    let a:params[key] = resolved[key]
+  let l:resolved = s:ResolveHookDict(a:hook, a:method, a:params)
+  for l:key in keys(l:resolved)
+    let a:params[l:key] = l:resolved[l:key]
   endfor
   return a:params
 endfunction
@@ -135,23 +135,23 @@ endfunction
 " [params] as arguments.
 function! s:ResolveHookDict(hook, method, params) abort
   if !s:HasFunction(a:hook) | return a:hook | endif
-  let copied = deepcopy(a:hook)
-  for key in keys(a:hook)
-    if type(a:hook[key]) == type({})
-      let copied[key] = s:ResolveHookDict(a:hook[key], a:method, a:params)
-    elseif type(a:hook[key]) == type({_->_})
-      let Func = a:hook[key]
-      let copied[key] = Func(a:method, a:params)
+  let l:copied = deepcopy(a:hook)
+  for l:key in keys(a:hook)
+    if type(a:hook[l:key]) == type({})
+      let l:copied[l:key] = s:ResolveHookDict(a:hook[l:key], a:method, a:params)
+    elseif type(a:hook[l:key]) == type({_->_})
+      let l:Func = a:hook[l:key]
+      let l:copied[l:key] = Func(a:method, a:params)
     endif
   endfor
-  return copied
+  return l:copied
 endfunction
 
 function! s:HasFunction(hook) abort
-  for Value in values(a:hook)
-    if type(Value) == type({}) && s:HasFunction(Value)
+  for l:Value in values(a:hook)
+    if type(l:Value) == type({}) && s:HasFunction(l:Value)
       return v:true
-    elseif type(Value) == type({_->_})
+    elseif type(l:Value) == type({_->_})
       return v:true
     endif
   endfor

--- a/autoload/lsc/convert.vim
+++ b/autoload/lsc/convert.vim
@@ -1,24 +1,25 @@
 function! lsc#convert#rangeToHighlights(range) abort
-  let start = a:range.start
-  let end = a:range.end
-  if end.line > start.line
-    let ranges =[[
-        \ start.line + 1,
-        \ start.character + 1,
+  let l:start = a:range.start
+  let l:end = a:range.end
+  if l:end.line > l:start.line
+    let l:ranges =[[
+        \ l:start.line + 1,
+        \ l:start.character + 1,
         \ 99]]
     " Matches render wrong until a `redraw!` if lines are mixed with ranges
-    call extend(ranges, map(range(start.line + 2, end.line), {_, l->[l,0,99]}))
-    call add(ranges, [
-        \ end.line + 1,
+    let l:lineHacks = map(range(l:start.line + 2, l:end.line), {_, l->[l,0,99]})
+    call extend(l:ranges, l:lineHacks)
+    call add(l:ranges, [
+        \ l:end.line + 1,
         \ 1,
-        \ end.character])
+        \ l:end.character])
   else
-    let ranges = [[
-        \ start.line + 1,
-        \ start.character + 1,
-        \ end.character - start.character]]
+    let l:ranges = [[
+        \ l:start.line + 1,
+        \ l:start.character + 1,
+        \ l:end.character - l:start.character]]
   endif
-  return ranges
+  return l:ranges
 endfunction
 
 " Convert an LSP SymbolInformation to a quick fix item.
@@ -39,19 +40,19 @@ endfunction
 " 'col': column number
 " 'text': "SymbolName" [kind] (in containerName)?
 function! lsc#convert#quickFixSymbol(symbol) abort
-  let item = {'lnum': a:symbol.location.range.start.line + 1,
+  let l:item = {'lnum': a:symbol.location.range.start.line + 1,
       \ 'col': a:symbol.location.range.start.character + 1,
       \ 'filename': lsc#uri#documentPath(a:symbol.location.uri)}
-  let text = '"'.a:symbol.name.'"'
+  let l:text = '"'.a:symbol.name.'"'
   if !empty(a:symbol.kind)
-    let text .= ' ['.lsc#convert#symbolKind(a:symbol.kind).']'
+    let l:text .= ' ['.lsc#convert#symbolKind(a:symbol.kind).']'
   endif
-  let containerName = get(a:symbol, 'containerName', '')
-  if !empty(containerName)
-    let text .= ' in '.containerName
+  let l:containerName = get(a:symbol, 'containerName', '')
+  if !empty(l:containerName)
+    let l:text .= ' in '.l:containerName
   endif
-  let item.text = text
-  return item
+  let l:item.text = l:text
+  return l:item
 endfunction
 
 function! lsc#convert#symbolKind(kind) abort

--- a/autoload/lsc/convert.vim
+++ b/autoload/lsc/convert.vim
@@ -7,8 +7,8 @@ function! lsc#convert#rangeToHighlights(range) abort
         \ l:start.character + 1,
         \ 99]]
     " Matches render wrong until a `redraw!` if lines are mixed with ranges
-    let l:lineHacks = map(range(l:start.line + 2, l:end.line), {_, l->[l,0,99]})
-    call extend(l:ranges, l:lineHacks)
+    let l:line_hacks = map(range(l:start.line + 2, l:end.line), {_, l->[l,0,99]})
+    call extend(l:ranges, l:line_hacks)
     call add(l:ranges, [
         \ l:end.line + 1,
         \ 1,

--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -49,8 +49,8 @@ function! lsc#cursor#showDiagnostic() abort
 endfunction
 
 function! lsc#cursor#onChangesFlushed() abort
-  let mode = mode()
-  if mode ==# 'n' || mode ==# 'no'
+  let l:mode = mode()
+  if l:mode ==# 'n' || l:mode ==# 'no'
     call s:HighlightReferences(v:true)
   endif
 endfunction
@@ -108,17 +108,17 @@ function! s:HandleHighlights(request_number, old_pos, old_buf_nr,
 
   let w:lsc_references = a:highlights
   let w:lsc_reference_matches = []
-  for reference in a:highlights
-    let match = matchaddpos('lscReference', reference.ranges, -5)
-    call add(w:lsc_reference_matches, match)
+  for l:reference in a:highlights
+    let l:match = matchaddpos('lscReference', l:reference.ranges, -5)
+    call add(w:lsc_reference_matches, l:match)
   endfor
 endfunction
 
 function! lsc#cursor#clean() abort
   let s:pending[&filetype] = v:false
   if exists('w:lsc_reference_matches')
-    for current_match in w:lsc_reference_matches
-      silent! call matchdelete(current_match)
+    for l:current_match in w:lsc_reference_matches
+      silent! call matchdelete(l:current_match)
     endfor
     unlet w:lsc_reference_matches
     unlet w:lsc_references
@@ -128,16 +128,18 @@ endfunction
 " Returns the index of the reference the cursor is positioned in, or -1 if it is
 " not in any reference.
 function! lsc#cursor#isInReference(references) abort
-  let line = line('.')
-  let col = col('.')
-  let idx = 0
-  for reference in a:references
-    for range in reference.ranges
-      if line == range[0] && col >= range[1] && col < range[1] + range[2]
-        return idx
+  let l:line = line('.')
+  let l:col = col('.')
+  let l:idx = 0
+  for l:reference in a:references
+    for l:range in l:reference.ranges
+      if l:line == l:range[0]
+          \ && l:col >= l:range[1]
+          \ && l:col < l:range[1] + l:range[2]
+        return l:idx
       endif
     endfor
-    let idx += 1
+    let l:idx += 1
   endfor
   return -1
 endfunction
@@ -147,10 +149,10 @@ function! s:ConvertReference(reference) abort
 endfunction
 
 function! s:CompareRange(r1, r2) abort
-  let line_1 = a:r1.ranges[0][0]
-  let line_2 = a:r2.ranges[0][0]
-  if line_1 != line_2 | return line_1 > line_2 ? 1 : -1 | endif
-  let col_1 = a:r1.ranges[0][1]
-  let col_2 = a:r2.ranges[0][1]
-  return col_1 - col_2
+  let l:line_1 = a:r1.ranges[0][0]
+  let l:line_2 = a:r2.ranges[0][0]
+  if l:line_1 != l:line_2 | return l:line_1 > l:line_2 ? 1 : -1 | endif
+  let l:col_1 = a:r1.ranges[0][1]
+  let l:col_2 = a:r2.ranges[0][1]
+  return l:col_1 - l:col_2
 endfunction

--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -15,9 +15,9 @@ if !exists('s:file_diagnostics')
 endif
 
 function! lsc#diagnostics#clean(filetype) abort
-  for buffer in getbufinfo({'bufloaded': v:true})
-    if getbufvar(buffer.bufnr, '&filetype') != a:filetype | continue | endif
-    call lsc#diagnostics#setForFile(lsc#file#normalize(buffer.name), [])
+  for l:buffer in getbufinfo({'bufloaded': v:true})
+    if getbufvar(l:buffer.bufnr, '&filetype') != a:filetype | continue | endif
+    call lsc#diagnostics#setForFile(lsc#file#normalize(l:buffer.name), [])
   endfor
 endfunction
 
@@ -49,7 +49,7 @@ endfunction
 function! s:DiagnosticMessage(diagnostic) abort
   let l:message = a:diagnostic.message
   if has_key(a:diagnostic, 'code')
-    let l:message = message.' ['.a:diagnostic.code.']'
+    let l:message = l:message.' ['.a:diagnostic.code.']'
   endif
   return l:message
 endfunction
@@ -326,28 +326,28 @@ function! s:Diagnostics(file_path, lsp_diagnostics) abort
       \ 'lsp_diagnostics': a:lsp_diagnostics,
       \}
   function! l:diagnostics.Highlights() abort
-    if !has_key(self, '_highlights')
-      let self._highlights = []
-      for l:diagnostic in self.lsp_diagnostics
-        call add(self._highlights, {
+    if !has_key(l:self, '_highlights')
+      let l:self._highlights = []
+      for l:diagnostic in l:self.lsp_diagnostics
+        call add(l:self._highlights, {
             \ 'group': s:SeverityGroup(l:diagnostic.severity),
             \ 'severity': l:diagnostic.severity,
             \ 'ranges': lsc#convert#rangeToHighlights(l:diagnostic.range),
             \})
       endfor
     endif
-    return self._highlights
+    return l:self._highlights
   endfunction
   function! l:diagnostics.ListItems() abort
-    if !has_key(self, '_list_items')
-      let self._list_items = []
-      let l:bufnr = lsc#file#bufnr(self.file_path)
+    if !has_key(l:self, '_list_items')
+      let l:self._list_items = []
+      let l:bufnr = lsc#file#bufnr(l:self.file_path)
       if l:bufnr == -1
-        let l:file_ref = {'filename': fnamemodify(self.file_path, ':.')}
+        let l:file_ref = {'filename': fnamemodify(l:self.file_path, ':.')}
       else
         let l:file_ref = {'bufnr': l:bufnr}
       endif
-      for l:diagnostic in self.lsp_diagnostics
+      for l:diagnostic in l:self.lsp_diagnostics
         let l:item = {
             \ 'lnum': l:diagnostic.range.start.line + 1,
             \ 'col': l:diagnostic.range.start.character + 1,
@@ -355,22 +355,22 @@ function! s:Diagnostics(file_path, lsp_diagnostics) abort
             \ 'type': s:SeverityType(l:diagnostic.severity)
             \}
         call extend(l:item, l:file_ref)
-        call add(self._list_items, l:item)
+        call add(l:self._list_items, l:item)
       endfor
-      call sort(self._list_items, 'lsc#util#compareQuickFixItems')
+      call sort(l:self._list_items, 'lsc#util#compareQuickFixItems')
     endif
-    return self._list_items
+    return l:self._list_items
   endfunction
   function! l:diagnostics.ByLine() abort
-    if !has_key(self, '_by_line')
-      let self._by_line = {}
-      for l:diagnostic in self.lsp_diagnostics
+    if !has_key(l:self, '_by_line')
+      let l:self._by_line = {}
+      for l:diagnostic in l:self.lsp_diagnostics
         let l:start_line = string(l:diagnostic.range.start.line + 1)
-        if !has_key(self._by_line, l:start_line)
+        if !has_key(l:self._by_line, l:start_line)
           let l:line = []
-          let self._by_line[l:start_line] = l:line
+          let l:self._by_line[l:start_line] = l:line
         else
-          let l:line = self._by_line[l:start_line]
+          let l:line = l:self._by_line[l:start_line]
         endif
         let l:simple = {
             \ 'message': s:DiagnosticMessage(l:diagnostic),
@@ -379,11 +379,11 @@ function! s:Diagnostics(file_path, lsp_diagnostics) abort
             \}
         call add(l:line, l:simple)
       endfor
-      for l:line in values(self._by_line)
+      for l:line in values(l:self._by_line)
         call sort(l:line, function('<SID>CompareRanges'))
       endfor
     endif
-    return self._by_line
+    return l:self._by_line
   endfunction
   return l:diagnostics
 endfunction

--- a/autoload/lsc/diff.vim
+++ b/autoload/lsc/diff.vim
@@ -5,31 +5,33 @@
 "
 " Finds a single change between the common prefix, and common postfix.
 function! lsc#diff#compute(old, new) abort
-  let [l:start_line, start_char] = s:FirstDifference(a:old, a:new)
-  let [end_line, end_char] =
+  let [l:start_line, l:start_char] = s:FirstDifference(a:old, a:new)
+  let [l:end_line, l:end_char] =
       \ s:LastDifference(a:old[l:start_line : ],
-      \ a:new[l:start_line : ], start_char)
+      \ a:new[l:start_line : ], l:start_char)
 
-  let text = s:ExtractText(a:new, l:start_line, start_char, end_line, end_char)
-  let length = s:Length(a:old, l:start_line, start_char, end_line, end_char)
+  let l:text =
+      \ s:ExtractText(a:new, l:start_line, l:start_char, l:end_line, l:end_char)
+  let l:length =
+      \ s:Length(a:old, l:start_line, l:start_char, l:end_line, l:end_char)
 
-  let adj_end_line = len(a:old) + end_line
-  let adj_end_char =
-      \ end_line == 0 ? 0 : strchars(a:old[end_line]) + end_char + 1
+  let l:adj_end_line = len(a:old) + l:end_line
+  let l:adj_end_char =
+      \ l:end_line == 0 ? 0 : strchars(a:old[l:end_line]) + l:end_char + 1
 
-  let result = { 'range': {
-      \  'start': {'line': l:start_line, 'character': start_char},
-      \  'end': {'line': adj_end_line, 'character': adj_end_char}},
-      \ 'text': text,
-      \ 'rangeLength': length,
+  let l:result = { 'range': {
+      \  'start': {'line': l:start_line, 'character': l:start_char},
+      \  'end': {'line': l:adj_end_line, 'character': l:adj_end_char}},
+      \ 'text': l:text,
+      \ 'rangeLength': l:length,
       \}
 
-  return result
+  return l:result
 endfunction
 
 let s:has_lua = has('lua') || has('nvim-0.4.0')
-" lua array and neovim vim list index starts with 1 while vim lists starts with 0.
-" starting patch-8.2.1066 vim lists array index was changed to start with 1.
+" neovim, and recent vim use 1-index in lua
+" older vim without patch-8.2.1066 lists use 0-index
 let s:lua_array_start_index = has('nvim-0.4.0') || has('patch-8.2.1066')
 
 if s:has_lua && !exists('s:lua')
@@ -68,8 +70,8 @@ let s:lua = 1
 " Finds the line and character of the first different character between two
 " list of Strings.
 function! s:FirstDifference(old, new) abort
-  let line_count = min([len(a:old), len(a:new)])
-  if line_count == 0 | return [0, 0] | endif
+  let l:line_count = min([len(a:old), len(a:new)])
+  if l:line_count == 0 | return [0, 0] | endif
   if s:has_lua
     let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
     let l:i = float2nr(luaeval('lsc_first_difference('
@@ -79,23 +81,25 @@ function! s:FirstDifference(old, new) abort
       if a:old[l:i] !=# a:new[l:i] | break | endif
     endfor
   endif
-  if i >= line_count
-    return [line_count - 1, strchars(a:old[line_count - 1])]
+  if l:i >= l:line_count
+    return [l:line_count - 1, strchars(a:old[l:line_count - 1])]
   endif
-  let old_line = a:old[i]
-  let new_line = a:new[i]
-  let length = min([strchars(old_line), strchars(new_line)])
-  let j = 0
-  while j < length
-    if strgetchar(old_line, j) != strgetchar(new_line, j) | break | endif
-    let j += 1
+  let l:old_line = a:old[l:i]
+  let l:new_line = a:new[l:i]
+  let l:length = min([strchars(l:old_line), strchars(l:new_line)])
+  let l:j = 0
+  while l:j < l:length
+    if strgetchar(l:old_line, l:j) != strgetchar(l:new_line, l:j)
+      break
+    endif
+    let l:j += 1
   endwhile
-  return [i, j]
+  return [l:i, l:j]
 endfunction
 
 function! s:LastDifference(old, new, start_char) abort
-  let line_count = min([len(a:old), len(a:new)])
-  if line_count == 0 | return [0, 0] | endif
+  let l:line_count = min([len(a:old), len(a:new)])
+  if l:line_count == 0 | return [0, 0] | endif
   if s:has_lua
     let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
     let l:i = float2nr(luaeval('lsc_last_difference('
@@ -105,26 +109,26 @@ function! s:LastDifference(old, new, start_char) abort
       if a:old[l:i] !=# a:new[l:i] | break | endif
     endfor
   endif
-  if i <= -1 * line_count
-    let i = -1 * line_count
-    let old_line = strcharpart(a:old[i], a:start_char)
-    let new_line = strcharpart(a:new[i], a:start_char)
+  if l:i <= -1 * l:line_count
+    let l:i = -1 * l:line_count
+    let l:old_line = strcharpart(a:old[l:i], a:start_char)
+    let l:new_line = strcharpart(a:new[l:i], a:start_char)
   else
-    let old_line = a:old[i]
-    let new_line = a:new[i]
+    let l:old_line = a:old[l:i]
+    let l:new_line = a:new[l:i]
   endif
-  let old_line_length = strchars(old_line)
-  let new_line_length = strchars(new_line)
-  let length = min([old_line_length, new_line_length])
-  let j = -1
-  while j >= -1 * length
-    if  strgetchar(old_line, old_line_length + j) !=
-        \ strgetchar(new_line, new_line_length + j)
+  let l:old_line_length = strchars(l:old_line)
+  let l:new_line_length = strchars(l:new_line)
+  let l:length = min([l:old_line_length, l:new_line_length])
+  let l:j = -1
+  while l:j >= -1 * l:length
+    if  strgetchar(l:old_line, l:old_line_length + l:j) !=
+        \ strgetchar(l:new_line, l:new_line_length + l:j)
       break
     endif
-    let j -= 1
+    let l:j -= 1
   endwhile
-  return [i, j]
+  return [l:i, l:j]
 endfunction
 
 function! s:ExtractText(lines, start_line, start_char, end_line, end_char) abort
@@ -134,33 +138,33 @@ function! s:ExtractText(lines, start_line, start_char, end_line, end_char) abort
     let l:length = strchars(l:line) + a:end_char - a:start_char + 1
     return strcharpart(l:line, a:start_char, l:length)
   endif
-  let result = strcharpart(a:lines[a:start_line], a:start_char)."\n"
-  for line in a:lines[a:start_line + 1:a:end_line - 1]
-    let result .= line."\n"
+  let l:result = strcharpart(a:lines[a:start_line], a:start_char)."\n"
+  for l:line in a:lines[a:start_line + 1:a:end_line - 1]
+    let l:result .= l:line."\n"
   endfor
   if a:end_line != 0
     let l:line = a:lines[a:end_line]
     let l:length = strchars(l:line) + a:end_char + 1
-    let result .= strcharpart(l:line, 0, l:length)
+    let l:result .= strcharpart(l:line, 0, l:length)
   endif
-  return result
+  return l:result
 endfunction
 
 function! s:Length(lines, start_line, start_char, end_line, end_char)
     \ abort
-  let adj_end_line = len(a:lines) + a:end_line
-  if adj_end_line >= len(a:lines)
-    let adj_end_char = a:end_char - 1
+  let l:adj_end_line = len(a:lines) + a:end_line
+  if l:adj_end_line >= len(a:lines)
+    let l:adj_end_char = a:end_char - 1
   else
-    let adj_end_char = strchars(a:lines[adj_end_line]) + a:end_char
+    let l:adj_end_char = strchars(a:lines[l:adj_end_line]) + a:end_char
   endif
-  if a:start_line == adj_end_line
-    return adj_end_char - a:start_char + 1
+  if a:start_line == l:adj_end_line
+    return l:adj_end_char - a:start_char + 1
   endif
-  let result = strchars(a:lines[a:start_line]) - a:start_char + 1
+  let l:result = strchars(a:lines[a:start_line]) - a:start_char + 1
   for l:line in range(a:start_line + 1, l:adj_end_line - 1)
-    let result += strchars(a:lines[l:line]) + 1
+    let l:result += strchars(a:lines[l:line]) + 1
   endfor
-  let result += adj_end_char + 1
-  return result
+  let l:result += l:adj_end_char + 1
+  return l:result
 endfunction

--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -63,10 +63,8 @@ function! s:ActionMenu(actions, OnSelected) abort
     return
   endif
   let l:choices = ['Choose an action:']
-  let l:idx = 0
-  while l:idx < len(a:actions)
-    call add(l:choices, string(l:idx+1).' - '.a:actions[l:idx]['title'])
-    let l:idx += 1
+  for l:index in range(a:actions)
+    call add(l:choices, string(l:index + 1).' - '.a:actions[l:index]['title'])
   endwhile
   let l:choice = inputlist(l:choices)
   if l:choice > 0

--- a/autoload/lsc/edit.vim
+++ b/autoload/lsc/edit.vim
@@ -65,7 +65,7 @@ function! s:ActionMenu(actions, OnSelected) abort
   let l:choices = ['Choose an action:']
   for l:index in range(a:actions)
     call add(l:choices, string(l:index + 1).' - '.a:actions[l:index]['title'])
-  endwhile
+  endfor
   let l:choice = inputlist(l:choices)
   if l:choice > 0
     call a:OnSelected(a:actions[l:choice - 1])

--- a/autoload/lsc/highlights.vim
+++ b/autoload/lsc/highlights.vim
@@ -36,8 +36,8 @@ endfunction
 " Remove all highlighted matches in the current window.
 function! lsc#highlights#clear() abort
   if exists('w:lsc_diagnostic_matches')
-    for current_match in w:lsc_diagnostic_matches
-      silent! call matchdelete(current_match)
+    for l:current_match in w:lsc_diagnostic_matches
+      silent! call matchdelete(l:current_match)
     endfor
   endif
   let w:lsc_diagnostic_matches = []
@@ -50,9 +50,9 @@ endfunction
 " update to highlights for after returning to normal mode. If vim enters insert
 " mode the text will be changed and highlights will update anyway.
 function! s:DeferForMode() abort
-  let mode = mode()
-  if mode ==# 's' || mode ==# 'S' || mode ==# "\<c-s>" ||
-      \ mode ==# 'v' || mode ==# 'V' || mode ==# "\<c-v>"
+  let l:mode = mode()
+  if l:mode ==# 's' || l:mode ==# 'S' || l:mode ==# "\<c-s>" ||
+      \ l:mode ==# 'v' || l:mode ==# 'V' || l:mode ==# "\<c-v>"
     call lsc#util#once('CursorHold,CursorMoved',
         \ function('lsc#highlights#updateDisplayed'))
     return v:true

--- a/autoload/lsc/message.vim
+++ b/autoload/lsc/message.vim
@@ -3,17 +3,16 @@ function! lsc#message#show(message, ...) abort
 endfunction
 
 function! lsc#message#showRequest(message, actions) abort
-  let options = [a:message]
-  let index = 0
-  while index < len(a:actions)
-    call add(options, (index + 1) . ' - ' . get(a:actions, index)['title'])
-    let index += 1
-  endwhile
-  let result = inputlist(options)
-  if result <= 0 || result - 1 > len(a:actions)
+  let l:options = [a:message]
+  for l:index in range(a:actions)
+    let l:title = get(a:actions, l:index)['title']
+    call add(l:options, (l:index + 1) . ' - ' . l:title)
+  endfor
+  let l:result = inputlist(l:options)
+  if l:result <= 0 || l:result - 1 > len(a:actions)
     return v:null
   else
-    return get(a:actions, result - 1)
+    return get(a:actions, l:result - 1)
   endif
 endfunction
 
@@ -26,9 +25,9 @@ function! lsc#message#error(message) abort
 endfunction
 
 function! s:Echo(echo_cmd, message, level) abort
-  let [level, hl_group] = s:Level(a:level)
-  exec 'echohl '.hl_group
-  exec a:echo_cmd.' "[lsc:'.level.'] ".a:message'
+  let [l:level, l:hl_group] = s:Level(a:level)
+  exec 'echohl '.l:hl_group
+  exec a:echo_cmd.' "[lsc:'.l:level.'] ".a:message'
   echohl None
 endfunction
 

--- a/autoload/lsc/signaturehelp.vim
+++ b/autoload/lsc/signaturehelp.vim
@@ -21,46 +21,46 @@ function! s:ShowHelp(signatureHelp) abort
     call lsc#message#show('No signature help available')
     return
   endif
-  let signatures = []
+  let l:signatures = []
   if has_key(a:signatureHelp, 'signatures')
     if type(a:signatureHelp.signatures) == type([])
-      let signatures = a:signatureHelp.signatures
+      let l:signatures = a:signatureHelp.signatures
     endif
   endif
 
-  if len(signatures) == 0
+  if len(l:signatures) == 0
     return
   endif
 
-  let active_signature = 0
+  let l:active_signature = 0
   if has_key(a:signatureHelp, 'activeSignature')
-    let active_signature = a:signatureHelp.activeSignature
-    if active_signature >= len(signatures)
-      let active_signature = 0
+    let l:active_signature = a:signatureHelp.activeSignature
+    if l:active_signature >= len(l:signatures)
+      let l:active_signature = 0
     endif
   endif
 
-  let signature = get(signatures, active_signature)
+  let l:signature = get(l:signatures, l:active_signature)
 
-  if !has_key(signature, 'label')
+  if !has_key(l:signature, 'label')
     return
   endif
 
-  if !has_key(signature, 'parameters')
-    call lsc#util#displayAsPreview([signature.label], &filetype,
+  if !has_key(l:signature, 'parameters')
+    call lsc#util#displayAsPreview([l:signature.label], &filetype,
         \ function('<SID>HighlightCurrentParameter'))
     return
   endif
 
   if has_key(a:signatureHelp, 'activeParameter')
-    let active_parameter = a:signatureHelp.activeParameter
-    if active_parameter < len(signature.parameters)
-        \ && has_key(signature.parameters[active_parameter], 'label')
-      let s:current_parameter = signature.parameters[active_parameter].label
+    let l:active_parameter = a:signatureHelp.activeParameter
+    if l:active_parameter < len(l:signature.parameters)
+        \ && has_key(l:signature.parameters[l:active_parameter], 'label')
+      let s:current_parameter = l:signature.parameters[l:active_parameter].label
     endif
   endif
 
-  call lsc#util#displayAsPreview([signature.label], &filetype,
+  call lsc#util#displayAsPreview([l:signature.label], &filetype,
       \ function('<SID>HighlightCurrentParameter'))
 
 endfunction

--- a/autoload/lsc/uri.vim
+++ b/autoload/lsc/uri.vim
@@ -17,8 +17,8 @@ function! s:EncodePath(value) abort
 endfunction
 
 function! s:EncodeChar(char) abort
-  let charcode = char2nr(a:char)
-  return printf('%%%02x', charcode)
+  let l:charcode = char2nr(a:char)
+  return printf('%%%02x', l:charcode)
 endfunction
 
 function! s:DecodePath(value) abort
@@ -27,8 +27,8 @@ function! s:DecodePath(value) abort
 endfunction
 
 function! s:DecodeChar(hexcode) abort
-  let charcode = str2nr(a:hexcode, 16)
-  return nr2char(charcode)
+  let l:charcode = str2nr(a:hexcode, 16)
+  return nr2char(l:charcode)
 endfunction
 
 function! s:filePrefix(...) abort

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -7,19 +7,19 @@ endif
 
 " Run `command` in all windows, keeping old open window.
 function! lsc#util#winDo(command) abort
-  let current_window = winnr()
+  let l:current_window = winnr()
   execute 'keepjumps noautocmd windo '.a:command
-  execute 'keepjumps noautocmd '.current_window.'wincmd w'
+  execute 'keepjumps noautocmd '.l:current_window.'wincmd w'
 endfunction
 
 " Schedule [function] to be called once for [event]. The function will only be
 " called if [event] fires for the current buffer. Callbacks cannot be canceled.
 function! lsc#util#once(event, function) abort
   let s:au_group_id += 1
-  let au_group = 'LSC_'.string(s:au_group_id)
-  let s:callbacks[au_group] = [a:function]
-  exec 'augroup '.au_group
-  exec 'autocmd '.a:event.' <buffer> call <SID>Callback("'.au_group.'")'
+  let l:au_group = 'LSC_'.string(s:au_group_id)
+  let s:callbacks[l:au_group] = [a:function]
+  exec 'augroup '.l:au_group
+  exec 'autocmd '.a:event.' <buffer> call <SID>Callback("'.l:au_group.'")'
   exec 'augroup END'
 endfunction
 
@@ -37,9 +37,9 @@ endfunction
 "
 " filenames within cwd are always considered to have a lower sort than others.
 function! lsc#util#compareQuickFixItems(i1, i2) abort
-  let file_1 = s:QuickFixFilename(a:i1)
-  let file_2 = s:QuickFixFilename(a:i2)
-  if file_1 != file_2
+  let l:file_1 = s:QuickFixFilename(a:i1)
+  let l:file_2 = s:QuickFixFilename(a:i2)
+  if l:file_1 != l:file_2
     return lsc#file#compare(l:file_1, l:file_2)
   endif
   if a:i1.lnum != a:i2.lnum | return a:i1.lnum - a:i2.lnum | endif
@@ -74,8 +74,8 @@ endfunction
 " After the content of the content of the preview window is set,
 " `function` is called (the buffer is still the preview).
 function! lsc#util#displayAsPreview(lines, filetype, function) abort
-  let view = winsaveview()
-  let alternate=@#
+  let l:view = winsaveview()
+  let l:alternate=@#
   call s:createOrJumpToPreview(s:countDisplayLines(a:lines, &previewheight))
   setlocal modifiable
   setlocal noreadonly
@@ -86,8 +86,8 @@ function! lsc#util#displayAsPreview(lines, filetype, function) abort
   setlocal nomodifiable
   setlocal readonly
   wincmd p
-  call winrestview(view)
-  let @#=alternate
+  call winrestview(l:view)
+  let @#=l:alternate
 endfunction
 
 " Approximates the number of lines it will take to display some text assuming an
@@ -106,21 +106,21 @@ function! s:countDisplayLines(lines, max) abort
 endfunction
 
 function! s:createOrJumpToPreview(want_height) abort
-  let windows = range(1, winnr('$'))
-  call filter(windows, {_, win -> getwinvar(win, "&previewwindow") == 1})
-  if len(windows) > 0
-    execute string(windows[0]).' wincmd W'
+  let l:windows = range(1, winnr('$'))
+  call filter(l:windows, {_, win -> getwinvar(win, "&previewwindow") == 1})
+  if len(l:windows) > 0
+    execute string(l:windows[0]).' wincmd W'
     edit __lsc_preview__
-    if winheight(windows[0]) < a:want_height
+    if winheight(l:windows[0]) < a:want_height
       execute 'resize '.a:want_height
     endif
   else
     if exists('g:lsc_preview_split_direction')
-      let direction = g:lsc_preview_split_direction
+      let l:direction = g:lsc_preview_split_direction
     else
-      let direction = ''
+      let l:direction = ''
     endif
-    execute direction.' '.string(a:want_height).'split __lsc_preview__'
+    execute l:direction.' '.string(a:want_height).'split __lsc_preview__'
     if exists('#User#LSCShowPreview')
       doautocmd <nomodeline> User LSCShowPreview
     endif
@@ -146,14 +146,15 @@ function! lsc#util#gateResult(name, callback, ...) abort
   else
     let s:callback_gates[a:name] += 1
   endif
-  let gate = s:callback_gates[a:name]
-  let old_pos = getcurpos()
+  let l:gate = s:callback_gates[a:name]
+  let l:old_pos = getcurpos()
   if a:0 >= 1 && type(a:1) == type({_->_})
-    let OnSkip = a:1
+    let l:OnSkip = a:1
   else
-    let OnSkip = v:false
+    let l:OnSkip = v:false
   endif
-  return function('<SID>Gated', [a:name, gate, old_pos, a:callback, OnSkip])
+  return function('<SID>Gated',
+      \ [a:name, l:gate, l:old_pos, a:callback, l:OnSkip])
 endfunction
 
 function! s:Gated(name, gate, old_pos, on_call, on_skip, ...) abort

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -63,10 +63,10 @@ endfunction
 " restarted the next time a window or tab is entered with this file type.
 function! RegisterLanguageServer(filetype, config) abort
   call lsc#server#register(a:filetype, a:config)
-  for buffer in getbufinfo({'bufloaded': v:true})
-    if getbufvar(buffer.bufnr, '&filetype') == a:filetype &&
-        \ getbufvar(buffer.bufnr, '&modifiable') &&
-        \ buffer.name !~# '\v^fugitive:///'
+  for l:buffer in getbufinfo({'bufloaded': v:true})
+    if getbufvar(l:buffer.bufnr, '&filetype') == a:filetype &&
+        \ getbufvar(l:buffer.bufnr, '&modifiable') &&
+        \ l:buffer.name !~# '\v^fugitive:///'
       call lsc#server#start(a:filetype)
       return
     endif

--- a/test/diff_test.vim
+++ b/test/diff_test.vim
@@ -203,15 +203,15 @@ function! TestDiff() abort
 endfunction
 
 function! s:TestDiff(range, length, text, old, new) abort
-  let start = {'line': a:range[0], 'character': a:range[1]}
-  let end = {'line': a:range[2], 'character': a:range[3]}
+  let l:start = {'line': a:range[0], 'character': a:range[1]}
+  let l:end = {'line': a:range[2], 'character': a:range[3]}
   let l:old = empty(a:old) ? [] : split(a:old, "\n", v:true)
   let l:new = empty(a:new) ? [] : split(a:new, "\n", v:true)
-  let result = lsc#diff#compute(l:old, l:new)
-  call assert_equal({'start': start}, {'start': result.range.start})
-  call assert_equal({'end': end}, {'end': result.range.end})
-  call assert_equal({'length': a:length}, {'length': result.rangeLength})
-  call assert_equal({'text': a:text}, {'text': result.text})
+  let l:result = lsc#diff#compute(l:old, l:new)
+  call assert_equal({'start': l:start}, {'start': l:result.range.start})
+  call assert_equal({'end': l:end}, {'end': l:result.range.end})
+  call assert_equal({'length': a:length}, {'length': l:result.rangeLength})
+  call assert_equal({'text': a:text}, {'text': l:result.text})
 endfunction
 
 function! s:RunTest(test)
@@ -221,8 +221,8 @@ function! s:RunTest(test)
   call function(a:test)()
 
   if len(v:errors) > 0
-    for error in v:errors
-      echoerr error
+    for l:error in v:errors
+      echoerr l:error
     endfor
   else
     echom 'No errors in: '.a:test
@@ -230,8 +230,8 @@ function! s:RunTest(test)
 endfunction
 
 function! s:RunTests(...)
-  for test in a:000
-    call s:RunTest(test)
+  for l:test in a:000
+    call s:RunTest(l:test)
   endfor
 endfunction
 

--- a/test/uri_test.vim
+++ b/test/uri_test.vim
@@ -15,8 +15,8 @@ function! s:RunTest(test)
   call function(a:test)()
 
   if len(v:errors) > 0
-    for error in v:errors
-      echoerr error
+    for l:error in v:errors
+      echoerr l:error
     endfor
   else
     echom 'No errors in: '.a:test
@@ -24,8 +24,8 @@ function! s:RunTest(test)
 endfunction
 
 function! s:RunTests(...)
-  for test in a:000
-    call s:RunTest(test)
+  for l:test in a:000
+    call s:RunTest(l:test)
   endfor
 endfunction
 


### PR DESCRIPTION
Enable the vint policy `ProhibitImplicitScopeVariable` and fix all
violations by prepending `l:`. Where the extra characters pushed lines
over 80 columns, adjust line breaks or extract variables to reduce
length. Refactor a while loop to a for-in-range loop.