### PR TITLE
Fix E461 Illegal Variable Name error in neovim

### DIFF
--- a/after/plugin/lsc.vim
+++ b/after/plugin/lsc.vim
@@ -3,6 +3,6 @@ let g:lsc_registered_commands = 1
 
 if !exists('g:lsc_server_commands') | finish | endif
 
-for [l:filetype, l:config] in items(g:lsc_server_commands)
-  call RegisterLanguageServer(l:filetype, l:config)
+for [s:filetype, s:config] in items(g:lsc_server_commands)
+  call RegisterLanguageServer(s:filetype, s:config)
 endfor


### PR DESCRIPTION
Apparently, neovim enforces that l: variables can only be used in a function.  Vim doesn't raise an error.