### PR TITLE
Don't start disabled servers

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -25,6 +25,7 @@ endif
 function! lsc#server#start(filetype) abort
   " Expect filetype is registered
   let l:server = s:servers[g:lsc_servers_by_filetype[a:filetype]]
+  if !l:server.config.enabled | return | endif
   call s:Start(l:server)
 endfunction
 

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -25,7 +25,7 @@ endif
 function! lsc#server#start(filetype) abort
   " Expect filetype is registered
   let l:server = s:servers[g:lsc_servers_by_filetype[a:filetype]]
-  if !l:server.config.enabled | return | endif
+  if !get(l:server.config, 'enabled', v:true) | return | endif
   call s:Start(l:server)
 endfunction
 
@@ -201,7 +201,7 @@ endfunction
 
 function! lsc#server#filetypeActive(filetype) abort
   let l:server = s:servers[g:lsc_servers_by_filetype[a:filetype]]
-  return !has_key(l:server.config, 'enabled') || l:server.config.enabled
+  return get(l:server.config, 'enabled', v:true)
 endfunction
 
 function! lsc#server#disable() abort
@@ -250,7 +250,7 @@ function! lsc#server#register(filetype, config) abort
     return
   endif
   let l:initial_status = 'not started'
-  if has_key(l:config, 'enabled') && !l:config.enabled
+  if !get(l:config, 'enabled', v:true)
     let l:initial_status = 'disabled'
   endif
   let l:server = {

--- a/test/integration/test/disabled_server_test.dart
+++ b/test/integration/test/disabled_server_test.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:_test/stub_lsp.dart';
+import 'package:_test/vim_remote.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:lsp/lsp.dart' show lspChannel;
+import 'package:test/test.dart';
+
+void main() {
+  group('initially disabled', () {
+    Stream<Peer> clients;
+    ServerSocket serverSocket;
+    Vim vim;
+    Peer client;
+
+    setUpAll(() async {
+      serverSocket = await ServerSocket.bind('localhost', 0);
+
+      clients = serverSocket.map((socket) {
+        return Peer(lspChannel(socket, socket),
+            onUnhandledError: (error, stack) {
+          fail('Unhandled server error: $error');
+        });
+      }).asBroadcastStream();
+      vim = await Vim.start();
+
+      // Register after a file is open
+      await vim.edit('foo.txt');
+      await vim.expr('RegisterLanguageServer("text", {'
+          '"command":"localhost:${serverSocket.port}",'
+          '"enabled":v:false,'
+          '})');
+    });
+    tearDownAll(() async {
+      await vim.quit();
+      final log = File(vim.name);
+      print(await log.readAsString());
+      await log.delete();
+      await serverSocket.close();
+    });
+
+    test('waits to start until explicitly enabled', () async {
+      expect(await vim.expr('lsc#server#status(\'text\')'), 'disabled');
+      final nextClient = clients.first;
+      await vim.sendKeys(':LSClientEnable<cr>');
+      client = await nextClient;
+      final server = StubServer(client);
+      await server.initialized;
+    });
+
+    tearDown(() async {
+      await vim.sendKeys(':LSClientDisable<cr>');
+      await vim.sendKeys(':%bwipeout!<cr>');
+      final file = File('foo.txt');
+      if (await file.exists()) await file.delete();
+      await client?.done;
+      client = null;
+    });
+  });
+}


### PR DESCRIPTION
If a buffer is already open for a filetype when `RegisterLangaugeServer`
is called the disabled configuration was ignored and the server was
started anyway.

Check whether the server is enabled before starting it. Add a test for
calling `RegisterLanguageServer` with an already open buffer for the
file type.