### PR TITLE
Centralize handing of setup and teardown

### DIFF
--- a/test/integration/lib/test_bed.dart
+++ b/test/integration/lib/test_bed.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:lsp/lsp.dart' show lspChannel;
+
+import 'vim_remote.dart';
+
+class TestBed {
+  final Vim vim;
+  final Stream<Peer> clients;
+
+  TestBed._(this.vim, this.clients);
+
+  static Future<TestBed> setup(
+      {Future<void> Function(Vim) beforeRegister}) async {
+    final serverSocket = await ServerSocket.bind('localhost', 0);
+
+    final clients = serverSocket.map((socket) {
+      final client =
+          Peer(lspChannel(socket, socket), onUnhandledError: (error, stack) {
+        fail('Unhandled server error: $error');
+      });
+      addTearDown(() => client.done);
+    }).asBroadcastStream();
+    final vim = await Vim.start();
+    await beforeRegister?.call(vim);
+    await vim.expr('RegisterLanguageServer("text", {'
+        '"command":"localhost:${serverSocket.port}",'
+        '"enabled":v:false,'
+        '})');
+
+    addTearDown(() async {
+      await vim.quit();
+      final log = File(vim.name);
+      print(await log.readAsString());
+      await log.delete();
+      await serverSocket.close();
+    });
+    return TestBed._(vim, clients);
+  }
+}

--- a/test/integration/pubspec.yaml
+++ b/test/integration/pubspec.yaml
@@ -7,6 +7,4 @@ environment:
 dependencies:
   lsp: ^0.1.1
   path: ^1.7.0
-
-dev_dependencies:
   test: ^1.13.0

--- a/test/integration/test/complete_test.dart
+++ b/test/integration/test/complete_test.dart
@@ -28,6 +28,7 @@ void main() {
     await testBed.vim.sendKeys(':%bwipeout!<cr>');
     final file = File('foo.txt');
     if (await file.exists()) await file.delete();
+    await client.done;
     client = null;
   });
 

--- a/test/integration/test/did_save_test.dart
+++ b/test/integration/test/did_save_test.dart
@@ -26,6 +26,7 @@ void main() {
     await testBed.vim.sendKeys(':%bwipeout!<cr>');
     final file = File('foo.txt');
     if (await file.exists()) await file.delete();
+    await client.done;
     client = null;
   });
 

--- a/test/integration/test/did_save_test.dart
+++ b/test/integration/test/did_save_test.dart
@@ -2,54 +2,31 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:_test/stub_lsp.dart';
-import 'package:_test/vim_remote.dart';
+import 'package:_test/test_bed.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
-import 'package:lsp/lsp.dart' show lspChannel;
 import 'package:test/test.dart';
 
 void main() {
-  Stream<Peer> clients;
-  ServerSocket serverSocket;
-  Vim vim;
+  TestBed testBed;
   Peer client;
 
   setUpAll(() async {
-    serverSocket = await ServerSocket.bind('localhost', 0);
-
-    clients = serverSocket.map((socket) {
-      return Peer(lspChannel(socket, socket), onUnhandledError: (error, stack) {
-        fail('Unhandled server error: $error');
-      });
-    }).asBroadcastStream();
-    vim = await Vim.start();
-    await vim.expr('RegisterLanguageServer("text", {'
-        '"command":"localhost:${serverSocket.port}",'
-        '"enabled":v:false,'
-        '})');
+    testBed = await TestBed.setup();
   });
 
   setUp(() async {
-    final nextClient = clients.first;
-    await vim.edit('foo.txt');
-    await vim.sendKeys(':LSClientEnable<cr>');
+    final nextClient = testBed.clients.first;
+    await testBed.vim.edit('foo.txt');
+    await testBed.vim.sendKeys(':LSClientEnable<cr>');
     client = await nextClient;
   });
 
   tearDown(() async {
-    await vim.sendKeys(':LSClientDisable<cr>');
-    await vim.sendKeys(':%bwipeout!<cr>');
+    await testBed.vim.sendKeys(':LSClientDisable<cr>');
+    await testBed.vim.sendKeys(':%bwipeout!<cr>');
     final file = File('foo.txt');
     if (await file.exists()) await file.delete();
-    await client.done;
     client = null;
-  });
-
-  tearDownAll(() async {
-    await vim.quit();
-    final log = File(vim.name);
-    print(await log.readAsString());
-    await log.delete();
-    await serverSocket.close();
   });
 
   Future<void> testNoDidSave(Map<String, dynamic> capabilities) async {
@@ -62,9 +39,9 @@ void main() {
 
     await server.didOpen.first;
 
-    await vim.sendKeys(':w<cr>');
+    await testBed.vim.sendKeys(':w<cr>');
 
-    await vim.sendKeys('iHello<esc>');
+    await testBed.vim.sendKeys('iHello<esc>');
     await await server.didChange.first;
   }
 
@@ -87,7 +64,7 @@ void main() {
 
     await server.didOpen.first;
 
-    await vim.sendKeys(':w<cr>');
+    await testBed.vim.sendKeys(':w<cr>');
 
     await server.didSave.first;
   });

--- a/test/integration/test/disabled_server_test.dart
+++ b/test/integration/test/disabled_server_test.dart
@@ -2,11 +2,13 @@ import 'dart:io';
 
 import 'package:_test/stub_lsp.dart';
 import 'package:_test/test_bed.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('initially disabled', () {
     TestBed testBed;
+    Peer client;
 
     setUpAll(() async {
       testBed = await TestBed.setup(beforeRegister: (vim) async {
@@ -14,20 +16,21 @@ void main() {
       });
     });
 
-    test('waits to start until explicitly enabled', () async {
-      expect(await testBed.vim.expr('lsc#server#status(\'text\')'), 'disabled');
-      final nextClient = testBed.clients.first;
-      await testBed.vim.sendKeys(':LSClientEnable<cr>');
-      final client = await nextClient;
-      final server = StubServer(client);
-      await server.initialized;
-    });
-
     tearDown(() async {
       await testBed.vim.sendKeys(':LSClientDisable<cr>');
       await testBed.vim.sendKeys(':%bwipeout!<cr>');
       final file = File('foo.txt');
       if (await file.exists()) await file.delete();
+      await client?.done;
+    });
+
+    test('waits to start until explicitly enabled', () async {
+      expect(await testBed.vim.expr('lsc#server#status(\'text\')'), 'disabled');
+      final nextClient = testBed.clients.first;
+      await testBed.vim.sendKeys(':LSClientEnable<cr>');
+      client = await nextClient;
+      final server = StubServer(client);
+      await server.initialized;
     });
   });
 }

--- a/test/integration/test/disabled_server_test.dart
+++ b/test/integration/test/disabled_server_test.dart
@@ -1,61 +1,33 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:_test/stub_lsp.dart';
-import 'package:_test/vim_remote.dart';
-import 'package:json_rpc_2/json_rpc_2.dart';
-import 'package:lsp/lsp.dart' show lspChannel;
+import 'package:_test/test_bed.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('initially disabled', () {
-    Stream<Peer> clients;
-    ServerSocket serverSocket;
-    Vim vim;
-    Peer client;
+    TestBed testBed;
 
     setUpAll(() async {
-      serverSocket = await ServerSocket.bind('localhost', 0);
-
-      clients = serverSocket.map((socket) {
-        return Peer(lspChannel(socket, socket),
-            onUnhandledError: (error, stack) {
-          fail('Unhandled server error: $error');
-        });
-      }).asBroadcastStream();
-      vim = await Vim.start();
-
-      // Register after a file is open
-      await vim.edit('foo.txt');
-      await vim.expr('RegisterLanguageServer("text", {'
-          '"command":"localhost:${serverSocket.port}",'
-          '"enabled":v:false,'
-          '})');
-    });
-    tearDownAll(() async {
-      await vim.quit();
-      final log = File(vim.name);
-      print(await log.readAsString());
-      await log.delete();
-      await serverSocket.close();
+      testBed = await TestBed.setup(beforeRegister: (vim) async {
+        await vim.edit('foo.txt');
+      });
     });
 
     test('waits to start until explicitly enabled', () async {
-      expect(await vim.expr('lsc#server#status(\'text\')'), 'disabled');
-      final nextClient = clients.first;
-      await vim.sendKeys(':LSClientEnable<cr>');
-      client = await nextClient;
+      expect(await testBed.vim.expr('lsc#server#status(\'text\')'), 'disabled');
+      final nextClient = testBed.clients.first;
+      await testBed.vim.sendKeys(':LSClientEnable<cr>');
+      final client = await nextClient;
       final server = StubServer(client);
       await server.initialized;
     });
 
     tearDown(() async {
-      await vim.sendKeys(':LSClientDisable<cr>');
-      await vim.sendKeys(':%bwipeout!<cr>');
+      await testBed.vim.sendKeys(':LSClientDisable<cr>');
+      await testBed.vim.sendKeys(':%bwipeout!<cr>');
       final file = File('foo.txt');
       if (await file.exists()) await file.delete();
-      await client?.done;
-      client = null;
     });
   });
 }

--- a/test/integration/test/edit_test.dart
+++ b/test/integration/test/edit_test.dart
@@ -27,6 +27,7 @@ void main() {
     await testBed.vim.sendKeys(':%bwipeout!<cr>');
     final file = File('foo.txt');
     if (await file.exists()) await file.delete();
+    await client.done;
     client = null;
   });
 

--- a/test/integration/test/edit_test.dart
+++ b/test/integration/test/edit_test.dart
@@ -2,55 +2,32 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:_test/stub_lsp.dart';
-import 'package:_test/vim_remote.dart';
+import 'package:_test/test_bed.dart';
 import 'package:test/test.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
-import 'package:lsp/lsp.dart'
-    show lspChannel, WorkspaceEdit, TextEdit, Range, Position;
+import 'package:lsp/lsp.dart' show WorkspaceEdit, TextEdit, Range, Position;
 
 void main() {
-  Stream<Peer> clients;
-  ServerSocket serverSocket;
-  Vim vim;
+  TestBed testBed;
   Peer client;
 
   setUpAll(() async {
-    serverSocket = await ServerSocket.bind('localhost', 0);
-
-    clients = serverSocket.map((socket) {
-      return Peer(lspChannel(socket, socket), onUnhandledError: (error, stack) {
-        fail('Unhandled server error: $error');
-      });
-    }).asBroadcastStream();
-    vim = await Vim.start();
-    await vim.expr('RegisterLanguageServer("text", {'
-        '"command":"localhost:${serverSocket.port}",'
-        '"enabled":v:false,'
-        '})');
+    testBed = await TestBed.setup();
   });
 
   setUp(() async {
-    final nextClient = clients.first;
-    await vim.edit('foo.txt');
-    await vim.sendKeys(':LSClientEnable<cr>');
+    final nextClient = testBed.clients.first;
+    await testBed.vim.edit('foo.txt');
+    await testBed.vim.sendKeys(':LSClientEnable<cr>');
     client = await nextClient;
   });
 
   tearDown(() async {
-    await vim.sendKeys(':LSClientDisable<cr>');
-    await vim.sendKeys(':%bwipeout!<cr>');
+    await testBed.vim.sendKeys(':LSClientDisable<cr>');
+    await testBed.vim.sendKeys(':%bwipeout!<cr>');
     final file = File('foo.txt');
     if (await file.exists()) await file.delete();
-    await client.done;
     client = null;
-  });
-
-  tearDownAll(() async {
-    await vim.quit();
-    final log = File(vim.name);
-    print(await log.readAsString());
-    await log.delete();
-    await serverSocket.close();
   });
 
   test('edit of entire file', () async {
@@ -75,10 +52,10 @@ void main() {
         });
     });
     await server.initialized;
-    await vim.sendKeys('ifoo<cr>foo<esc>');
-    await vim.sendKeys(':LSClientRename \'bar\'<cr>');
+    await testBed.vim.sendKeys('ifoo<cr>foo<esc>');
+    await testBed.vim.sendKeys(':LSClientRename \'bar\'<cr>');
     await renameDone;
     await Future.delayed(const Duration(milliseconds: 100));
-    expect(await vim.expr(r'getline(1, "$")'), 'bar\nbar\n');
+    expect(await testBed.vim.expr(r'getline(1, "$")'), 'bar\nbar\n');
   });
 }

--- a/test/integration/test/stderr_test.dart
+++ b/test/integration/test/stderr_test.dart
@@ -45,7 +45,7 @@ void main() {
     }
     final messages = await vim.messages(2);
     expect(messages, [
-      matches('"foo.txt" .* --No lines in buffer--'),
+      matches('"foo.txt" .*--No lines in buffer--'),
       '[lsc:Error] Failed to initialize server "some server". '
           'Failing command is: [\'sh\', \'-c\', \'echo messagestderr >&2\']'
     ]);

--- a/test/integration/test/workspace_configuration_test.dart
+++ b/test/integration/test/workspace_configuration_test.dart
@@ -10,7 +10,9 @@ void main() {
   Peer client;
 
   setUpAll(() async {
-    testBed = await TestBed.setup();
+    testBed = await TestBed.setup(
+        config:
+            '"workspace_config":{"foo":{"baz":"bar"},"other":"something"},');
   });
 
   setUp(() async {
@@ -25,6 +27,7 @@ void main() {
     await testBed.vim.sendKeys(':%bwipeout!<cr>');
     final file = File('foo.txt');
     if (await file.exists()) await file.delete();
+    await client.done;
     client = null;
   });
 

--- a/test/integration/test/workspace_configuration_test.dart
+++ b/test/integration/test/workspace_configuration_test.dart
@@ -1,54 +1,31 @@
 import 'dart:io';
 
 import 'package:_test/stub_lsp.dart';
-import 'package:_test/vim_remote.dart';
+import 'package:_test/test_bed.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
-import 'package:lsp/lsp.dart' show lspChannel;
 import 'package:test/test.dart';
 
 void main() {
-  Stream<Peer> clients;
-  Vim vim;
+  TestBed testBed;
   Peer client;
 
   setUpAll(() async {
-    final serverSocket = await ServerSocket.bind('localhost', 0);
-    addTearDown(serverSocket.close);
-
-    clients = serverSocket.map((socket) {
-      return Peer(lspChannel(socket, socket), onUnhandledError: (error, _) {
-        fail('Unhandled server error: $error');
-      });
-    }).asBroadcastStream();
-    vim = await Vim.start();
-    await vim.expr('RegisterLanguageServer("text", {'
-        '"command":"localhost:${serverSocket.port}",'
-        '"workspace_config":{"foo":{"baz":"bar"},"other":"something"},'
-        '"enabled":v:false,'
-        '})');
+    testBed = await TestBed.setup();
   });
 
   setUp(() async {
-    final nextClient = clients.first;
-    await vim.edit('foo.txt');
-    await vim.sendKeys(':LSClientEnable<cr>');
+    final nextClient = testBed.clients.first;
+    await testBed.vim.edit('foo.txt');
+    await testBed.vim.sendKeys(':LSClientEnable<cr>');
     client = await nextClient;
   });
 
   tearDown(() async {
-    await vim.sendKeys(':LSClientDisable<cr>');
-    await vim.sendKeys(':%bwipeout!<cr>');
+    await testBed.vim.sendKeys(':LSClientDisable<cr>');
+    await testBed.vim.sendKeys(':%bwipeout!<cr>');
     final file = File('foo.txt');
     if (await file.exists()) await file.delete();
-    await client.done;
     client = null;
-  });
-
-  tearDownAll(() async {
-    await vim.quit();
-    final log = File(vim.name);
-    print(await log.readAsString());
-    await log.delete();
   });
 
   test('can send workspace configuration', () async {


### PR DESCRIPTION
Add a `TestBed` class with a static method covering the set up all
behavior and automatically add the `tearDownAll` behavior.
Reduces some boilerplate for the common pattern of starting a
server on a local socket.