### PR TITLE
Handle &modifiable in `IfEnable`

### DIFF
--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -5,22 +5,12 @@ if !exists('s:initialized')
 endif
 
 function! lsc#cursor#onMove() abort
-  if !&modifiable | return | endif
   call lsc#cursor#showDiagnostic()
   call s:HighlightReferences(v:false)
 endfunction
 
-function! lsc#cursor#onWinLeave() abort
-  call lsc#cursor#clean()
-endfunction
-
 function! lsc#cursor#onWinEnter() abort
-  if !&modifiable | return | endif
   call s:HighlightReferences(v:false)
-endfunction
-
-function! lsc#cursor#insertEnter() abort
-  call lsc#cursor#clean()
 endfunction
 
 function! lsc#cursor#showDiagnostic() abort

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -99,9 +99,8 @@ augroup LSC
   autocmd BufWritePost * call <SID>OnWrite()
 
   autocmd CursorMoved * call <SID>IfEnabled('lsc#cursor#onMove')
-  autocmd WinLeave * call <SID>IfEnabled('lsc#cursor#onWinLeave')
   autocmd WinEnter * call <SID>IfEnabled('lsc#cursor#onWinEnter')
-  autocmd InsertEnter * call <SID>IfEnabled('lsc#cursor#insertEnter')
+  autocmd WinLeave,InsertEnter * call <SID>IfEnabled('lsc#cursor#clean')
   autocmd User LSCOnChangesFlushed
       \ call <SID>IfEnabled('lsc#cursor#onChangesFlushed')
 
@@ -154,6 +153,7 @@ endfunction
 " the current buffer where '&filetype' can be trusted.
 function! s:IfEnabled(function, ...) abort
   if !has_key(g:lsc_servers_by_filetype, &filetype) | return | endif
+  if !&modifiable | return | endif
   if !lsc#server#filetypeActive(&filetype) | return | endif
   call call(a:function, a:000)
 endfunction


### PR DESCRIPTION
Reduces some duplication. All the gated calls either already ignore
unmodifiable buffers, or can safely ignore unmodifiable buffers.

Inline and merge two autocommands which both only forwarded to
`lsc#cursor#clean()`.