### PR TITLE
Add clientInfo name to the initializeParams.

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -154,6 +154,7 @@ function! s:Start(server) abort
     let l:trace_level = 'off'
   endif
   let l:params = {'processId': getpid(),
+      \ 'clientInfo': {'name': 'vim-lsc'},
       \ 'rootUri': lsc#uri#documentUri(lsc#file#cwd()),
       \ 'capabilities': s:ClientCapabilities(),
       \ 'trace': l:trace_level


### PR DESCRIPTION
Some servers (like Metals), use this to display the client in the logs.
This only adds in the name, not the version.

https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize