### PR TITLE
Remove extra call to lsc#config#mapKeys

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -22,7 +22,6 @@ endfunction
 " Run language servers for this filetype if they aren't already running and
 " flush file changes.
 function! lsc#file#onOpen() abort
-  call lsc#config#mapKeys()
   if &modifiable && expand('%') !~# '\vfugitive:///'
     call lsc#server#start(&filetype)
     call s:FlushChanges(lsc#file#fullPath(), &filetype)


### PR DESCRIPTION
Every call to `lsc#file#onOpen` would have already called
`lsc#config#mapKeys`. This call should have been removed in
e606368a5c5114b3cb893a7dd904c7fd6c3c7d15