### PR TITLE
Don't map keys in fugitive buffers

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -22,10 +22,8 @@ endfunction
 " Run language servers for this filetype if they aren't already running and
 " flush file changes.
 function! lsc#file#onOpen() abort
-  if &modifiable && expand('%') !~# '\vfugitive:///'
-    call lsc#server#start(&filetype)
-    call s:FlushChanges(lsc#file#fullPath(), &filetype)
-  endif
+  call lsc#server#start(&filetype)
+  call s:FlushChanges(lsc#file#fullPath(), &filetype)
 endfunction
 
 function! lsc#file#onClose(full_path, filetype) abort

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -160,7 +160,9 @@ endfunction
 
 function! s:OnOpen() abort
   if !has_key(g:lsc_servers_by_filetype, &filetype) | return | endif
+  if expand('%') =~# '\vfugitive:///' | return | endif
   call lsc#config#mapKeys()
+  if !&modifiable | return | endif
   if !lsc#server#filetypeActive(&filetype) | return | endif
   call lsc#file#onOpen()
 endfunction


### PR DESCRIPTION
Move the checks for unmodifiable or fugitive buffers to `s:OnOpen` which
is also calling to configure key maps. Move the modifiable check as well
for more consistency with `IfEnabled` which started checking modifiable
in #372