### PR TITLE
Handle per-server file sync and startup

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -37,7 +37,7 @@ function! lsc#file#onOpen() abort
     let l:bufnr = bufnr()
     for l:server in lsc#server#forFileType(&filetype)
       if !get(l:server.config, 'enabled', v:true) | continue | endif
-      if l:server.status == 'running'
+      if l:server.status ==# 'running'
         call s:DidOpen(l:server, l:bufnr, l:file_path, &filetype)
       else
         call lsc#server#start(l:server)
@@ -148,7 +148,7 @@ function! s:FlushIfChanged(file_path, filetype) abort
       \ }
   let l:current_content = getbufline(lsc#file#bufnr(a:file_path), 1, '$')
   for l:server in lsc#server#forFileType(a:filetype)
-    if l:server.status != 'running' | continue | endif
+    if l:server.status !=# 'running' | continue | endif
     if l:server.capabilities.textDocumentSync.incremental
       if !exists('l:incremental_params')
         let l:old_content = s:file_content[a:file_path]

--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -10,20 +10,40 @@ if !exists('s:initialized')
   let s:normalized_paths = {}
 endif
 
-" Send a 'didOpen' message for all open files of type `filetype` if they aren't
-" already tracked.
-function! lsc#file#trackAll(filetype) abort
+" Send a 'didOpen' message for all open buffers with a tracked file type for a
+" running server.
+function! lsc#file#trackAll(server) abort
   for l:buffer in getbufinfo({'bufloaded': v:true})
-    if getbufvar(l:buffer.bufnr, '&filetype') != a:filetype | continue | endif
-    call s:FlushChanges(lsc#file#normalize(l:buffer.name), a:filetype)
+    if !getbufvar(l:buffer.bufnr, '&modifiable') | continue | endif
+    if  l:buffer.name =~# '\vfugitive:///' | continue | endif
+    let l:filetype = getbufvar(l:buffer.bufnr, '&filetype')
+    if index(a:server.filetypes, l:filetype) < 0 | continue | endif
+    call lsc#file#track(a:server, l:buffer, l:filetype)
   endfor
+endfunction
+
+function! lsc#file#track(server, buffer, filetype) abort
+  let l:file_path = lsc#file#normalize(a:buffer.name)
+  call s:DidOpen(a:server, a:buffer.bufnr, l:file_path, a:filetype)
 endfunction
 
 " Run language servers for this filetype if they aren't already running and
 " flush file changes.
 function! lsc#file#onOpen() abort
-  call lsc#server#start(&filetype)
-  call s:FlushChanges(lsc#file#fullPath(), &filetype)
+  let l:file_path = lsc#file#fullPath()
+  if has_key(s:file_versions, l:file_path)
+    call lsc#file#flushChanges()
+  else
+    let l:bufnr = bufnr()
+    for l:server in lsc#server#forFileType(&filetype)
+      if !get(l:server.config, 'enabled', v:true) | continue | endif
+      if l:server.status == 'running'
+        call s:DidOpen(l:server, l:bufnr, l:file_path, &filetype)
+      else
+        call lsc#server#start(l:server)
+      endif
+    endfor
+  endif
 endfunction
 
 function! lsc#file#onClose(full_path, filetype) abort
@@ -55,27 +75,24 @@ function! lsc#file#flushChanges() abort
 endfunction
 
 " Send the 'didOpen' message for a file.
-function! s:DidOpen(file_path) abort
-  let l:bufnr = lsc#file#bufnr(a:file_path)
-  if !bufloaded(l:bufnr) | return | endif
-  if !getbufvar(l:bufnr, '&modifiable') | return | endif
-  let l:buffer_content = getbufline(l:bufnr, 1, '$')
-  let l:filetype = getbufvar(l:bufnr, '&filetype')
+function! s:DidOpen(server, bufnr, file_path, filetype) abort
+  let l:buffer_content = has_key(s:file_content, a:file_path)
+      \ ? s:file_content[a:file_path]
+      \ : getbufline(a:bufnr, 1, '$')
+  let l:version = has_key(s:file_versions, a:file_path)
+      \ ? s:file_versions[a:file_path]
+      \ : 1
   let l:params = {'textDocument':
       \   {'uri': lsc#uri#documentUri(a:file_path),
-      \    'version': 1,
-      \    'text': join(l:buffer_content, "\n")."\n"
+      \    'version': l:version,
+      \    'text': join(l:buffer_content, "\n")."\n",
+      \    'languageId': a:server.languageId[a:filetype],
       \   }
       \ }
-  " TODO handle multiple servers
-  let l:success = v:false
-  for l:server in lsc#server#forFileType(l:filetype)
-    let l:params.textDocument.languageId = l:server.languageId[l:filetype]
-    let l:success = l:server.notify('textDocument/didOpen', l:params)
-  endfor
-  if l:success
-    let s:file_versions[a:file_path] = 1
-    if s:AllowIncrementalSync(l:filetype)
+  if a:server.notify('textDocument/didOpen', l:params)
+    let s:file_versions[a:file_path] = l:version
+    if get(g:, 'lsc_enable_incremental_sync', v:true)
+        \ && a:server.capabilities.textDocumentSync.incremental
       let s:file_content[a:file_path] = l:buffer_content
     endif
     doautocmd <nomodeline> User LSCOnChangesFlushed
@@ -112,64 +129,50 @@ function! lsc#file#onChange(...) abort
       \   {'repeat': 1})
 endfunction
 
-" Flushes only if `onChange` had previously been called for the file and the
-" changes aren't yet flusehd.
+" Flushes only if `onChange` had previously been called for the file and those
+" changes aren't flushed yet, and the file is tracked by at least one server.
 function! s:FlushIfChanged(file_path, filetype) abort
-  if has_key(s:flush_timers, a:file_path)
-    call s:FlushChanges(a:file_path, a:filetype)
-  endif
-endfunction
-
-" Changes are flushed after 500ms of inactivity or before leaving the buffer.
-function! s:FlushChanges(file_path, filetype) abort
-  if !has_key(s:file_versions, a:file_path)
-    call s:DidOpen(a:file_path)
-    return
-  endif
+  " Buffer may not have any pending changes to flush.
+  if !has_key(s:flush_timers, a:file_path) | return | endif
+  " Buffer may not be tracked with a `didOpen` call by any server yet.
+  if !has_key(s:file_versions, a:file_path) | return | endif
   let s:file_versions[a:file_path] += 1
   if has_key(s:flush_timers, a:file_path)
     call timer_stop(s:flush_timers[a:file_path])
     unlet s:flush_timers[a:file_path]
   endif
-  let l:current_content = getbufline(lsc#file#bufnr(a:file_path), 1, '$')
-  let l:allow_incremental = s:AllowIncrementalSync(a:filetype)
-  if l:allow_incremental
-    let l:old_content = s:file_content[a:file_path]
-    let l:change = lsc#diff#compute(l:old_content, l:current_content)
-  else
-    let l:change = {'text': join(l:current_content, "\n")."\n"}
-  endif
-  let l:params = {'textDocument':
+  let l:document_params = {'textDocument':
       \   {'uri': lsc#uri#documentUri(a:file_path),
       \    'version': s:file_versions[a:file_path],
       \   },
-      \ 'contentChanges': [l:change],
       \ }
-  " TODO handle multiple servers
+  let l:current_content = getbufline(lsc#file#bufnr(a:file_path), 1, '$')
   for l:server in lsc#server#forFileType(a:filetype)
-    call l:server.notify('textDocument/didChange', l:params)
+    if l:server.status != 'running' | continue | endif
+    if l:server.capabilities.textDocumentSync.incremental
+      if !exists('l:incremental_params')
+        let l:old_content = s:file_content[a:file_path]
+        let l:change = lsc#diff#compute(l:old_content, l:current_content)
+        let s:file_content[a:file_path] = l:current_content
+        let l:incremental_params = copy(l:document_params)
+        let l:incremental_params.contentChanges = [l:change]
+      endif
+      let l:params = l:incremental_params
+    else
+      if !exists('l:full_params')
+        let l:full_params = copy(l:document_params)
+        let l:change = {'text': join(l:current_content, "\n")."\n"}
+        let l:full_params.contentChanges = [l:change]
+      endif
+      let l:params = l:full_params
+    endif
+      call l:server.notify('textDocument/didChange', l:params)
   endfor
-  if l:allow_incremental
-    let s:file_content[a:file_path] = l:current_content
-  endif
   doautocmd <nomodeline> User LSCOnChangesFlushed
 endfunction
 
 function! lsc#file#version() abort
   return get(s:file_versions, lsc#file#fullPath(), '')
-endfunction
-
-function! s:AllowIncrementalSync(filetype) abort
-  if (exists('g:lsc_enable_incremental_sync')
-      \ && !g:lsc_enable_incremental_sync)
-    return v:false
-  endif
-  for l:server in lsc#server#forFileType(a:filetype)
-    if !l:server.capabilities.textDocumentSync.incremental
-      return v:false
-    endif
-  endfor
-  return v:true
 endfunction
 
 " The full path to the current buffer.

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -66,7 +66,7 @@ function! RegisterLanguageServer(filetype, config) abort
   if !get(l:server.config, 'enabled', v:true) | return | endif
   let l:buffers = s:BuffersOfType(a:filetype)
   if empty(l:buffers) | return | endif
-  if l:server.status == 'running'
+  if l:server.status ==# 'running'
     for l:buffer in l:buffers
       call lsc#file#track(l:server, l:buffer, a:filetype)
     endfor

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -62,15 +62,29 @@ endfunction
 " subsequent appearances of this file type. If the server exits it will be
 " restarted the next time a window or tab is entered with this file type.
 function! RegisterLanguageServer(filetype, config) abort
-  call lsc#server#register(a:filetype, a:config)
+  let l:server = lsc#server#register(a:filetype, a:config)
+  if !get(l:server.config, 'enabled', v:true) | return | endif
+  let l:buffers = s:BuffersOfType(a:filetype)
+  if empty(l:buffers) | return | endif
+  if l:server.status == 'running'
+    for l:buffer in l:buffers
+      call lsc#file#track(l:server, l:buffer, a:filetype)
+    endfor
+  else
+    call lsc#server#start(l:server)
+  endif
+endfunction
+
+function! s:BuffersOfType(filetype) abort
+  let l:buffers = []
   for l:buffer in getbufinfo({'bufloaded': v:true})
     if getbufvar(l:buffer.bufnr, '&filetype') == a:filetype &&
         \ getbufvar(l:buffer.bufnr, '&modifiable') &&
         \ l:buffer.name !~# '\v^fugitive:///'
-      call lsc#server#start(a:filetype)
-      return
+      call add(l:buffers, l:buffer)
     endif
   endfor
+  return l:buffers
 endfunction
 
 augroup LSC

--- a/test/integration/lib/stub_lsp.dart
+++ b/test/integration/lib/stub_lsp.dart
@@ -14,6 +14,7 @@ class StubServer {
         _initialized.complete();
       })
       ..registerMethod('workspace/didChangeConfiguration', (_) {})
+      ..registerMethod('textDocument/didClose', (_) {})
       ..registerMethod('textDocument/didOpen', _didOpen.add)
       ..registerMethod('textDocument/didChange', _didChange.add)
       ..registerMethod('textDocument/didSave', _didSave.add)

--- a/test/integration/lib/test_bed.dart
+++ b/test/integration/lib/test_bed.dart
@@ -25,6 +25,7 @@ class TestBed {
     await beforeRegister?.call(vim);
     await vim.expr('RegisterLanguageServer("text", {'
         '"command":"localhost:${serverSocket.port}",'
+        '"name":"Test Server",'
         '"enabled":v:false,'
         '$config'
         '})');

--- a/test/integration/pubspec.yaml
+++ b/test/integration/pubspec.yaml
@@ -5,6 +5,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
+  async: ^2.4.0
   lsp: ^0.1.1
   path: ^1.7.0
   test: ^1.13.0

--- a/test/integration/test/did_open_test.dart
+++ b/test/integration/test/did_open_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:async/async.dart';
+import 'package:_test/stub_lsp.dart';
+import 'package:_test/test_bed.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Registering a new file type', () {
+    TestBed testBed;
+    Peer client;
+
+    setUpAll(() async {
+      testBed = await TestBed.setup();
+    });
+
+    setUp(() async {
+      final nextClient = testBed.clients.first;
+      await testBed.vim.edit('foo.txt');
+      await testBed.vim.sendKeys(':LSClientEnable<cr>');
+      client = await nextClient;
+    });
+
+    tearDown(() async {
+      await testBed.vim.sendKeys(':LSClientDisable<cr>');
+      await testBed.vim.sendKeys(':%bwipeout!<cr>');
+      final file = File('foo.txt');
+      if (await file.exists()) await file.delete();
+      await client.done;
+      client = null;
+    });
+
+    test('sends didOpen for already open files', () async {
+      final server = StubServer(client);
+      final opens = StreamQueue(server.didOpen);
+
+      await server.initialized;
+      await opens.next;
+
+      await testBed.vim.edit('foo.py');
+      await testBed.vim.expr('RegisterLanguageServer("python", "Test Server")');
+      final nextOpen = await opens.next;
+      expect(nextOpen['textDocument']['uri'].asString, endsWith('foo.py'));
+    });
+  });
+}


### PR DESCRIPTION
Towards #57

Change `lsc#server#start` to take a specific server instead of a
filetype. Return the server from `lsc#server#register` to allow
`RegisterLanguageServer` to pass it back to `lsc#server#start`. When
registering a server choose between starting it, or tracking buffers of
the newly registered filetype if the server is already running.

Start to separate the per-server pieces of file tracking. Still only
allows a single server per filetype in `server.vim`.

At server startup, track all files for the specific server rather than
all servers for the filetype. If multiple servers were allowed this
would prevent sending `didOpen` to already running server when a new one
starts. Pass the server instead of the filetype to `lsc#file#trackAll`.
Add `lsc#file#track` to track a specific buffer for the
`RegisterLanguageServer` case.

Remove the fallback to sending `didOpen` instead of `didChange` when
flushing file changes. Originally `s:DidOpen` could call
`lsc#file#flushChanges` because an `:edit` for an already open file
would call again, and the changes should be flushed instead of an
erroneous second `didOpen` for an already open file.
03eb193e0d52dc1bb901f1c501f2367d8c9da93e
Later this was reversed and `s:FlushChanges` was always the called
function, and it could instead call `s:DidOpen`.
3a37c0deba2535d045863ab382f5b9f072cadbc9

In the new design `s:DidOpen` is only called from the code paths which
should intentionally send the `didOpen` notification, instead of needing
to check at call time whether to send a `didOpen` or a `didChange`. The
`didOpen` notification is sent in the specific cases where the server
cannot have already received it - starting up a server and tracking all
relevant files, opening a new buffer which has not been handled at all,
or registering a language server for a new file type. For the latter 2
cases callers disambiguate between starting the server or sending
`didOpen` based on whether the server is already running. This fixes a
bug in `RegisterLanguageServer` which caused already open files to not
be tracked if an existing serve is configured to work for a new
filetype. Currently the new server and opened buffer paths both need to
check for a disabled server. The call to start servers is safe to make
repeatedly, even if the server is already starting up.

Calls to `lsc#file#flushChanges` triggered by the plugin before making
some other request like completion or references are ignored if the
buffer isn't already tracked. In those cases the call to the server
should not be made anyway, since the only way for a server to not track
an already open buffer is if it is not yet `'running'`, the call to
`lsc#file#trackAll` is done synchronously following the status change.

When calling `didOpen`, reuse buffer content from `s:file_contents` if
it exists instead of reading current buffer content. If a server starts
up after files are already tracked, the point at which `didOpen` is
called will match the point from which a diff is computed for the next
`didChange` call. The spec does not state the version must start at any
particular number, and allows for non-consecutive versions. Since the
version and content are always updated in the same method synchronously,
this should keep all sent messages sane for every server. The `didOpen`
calls are sent synchronously following the server's status change to
`'running'`, so it is safe to silently drop the `didChange` calls before a
server is running and know that they will pick back up from the correct
point when it is running.