### PR TITLE
Add flush debounce time configuration.

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -123,8 +123,13 @@ function! lsc#file#onChange(...) abort
   if has_key(s:flush_timers, l:file_path)
     call timer_stop(s:flush_timers[l:file_path])
   endif
+  if exists('g:lsc_change_flush_debounce')
+    let l:flush_timeout = g:lsc_change_flush_debounce
+  else
+    let l:flush_timeout = 500
+  endif
   let s:flush_timers[l:file_path] =
-      \ timer_start(500,
+      \ timer_start(l:flush_timeout,
       \   {_->s:FlushIfChanged(file_path, filetype)},
       \   {'repeat': 1})
 endfunction

--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -123,13 +123,8 @@ function! lsc#file#onChange(...) abort
   if has_key(s:flush_timers, l:file_path)
     call timer_stop(s:flush_timers[l:file_path])
   endif
-  if exists('g:lsc_change_flush_debounce')
-    let l:flush_timeout = g:lsc_change_flush_debounce
-  else
-    let l:flush_timeout = 500
-  endif
   let s:flush_timers[l:file_path] =
-      \ timer_start(l:flush_timeout,
+      \ timer_start(get(g:, 'lsc_change_debounce_time', 500),
       \   {_->s:FlushIfChanged(file_path, filetype)},
       \   {'repeat': 1})
 endfunction

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -215,6 +215,13 @@ an empty string. The possible statuses are:
 
 CONFIGURATION                                   *lsc-configure*
 
+                                                *g:lsc_change_debounce_time*
+Set the time in milliseconds to wait for subsequent changes before flushing
+buffer content to the server as a `document/didChange` notification. Some
+features, such as autocomplete, may cause changes to be flushed before the
+debounce period has settled. Defaults to `500` milliseconds.
+
+
                                                 *lsc-configure-trace*
                                                 *g:lsc_trace_level*
 Set the "trace" field sent to the server during initialization using the


### PR DESCRIPTION
Some forms of interaction include different input patterns, such as when
using speech to text software, where it may be useful to flush changes
much more rapidly than the default value of 500ms used when typing.

--------

Background/Motivation: I am working on integrating some speech-to-text software (talonvoice.com) with my workflow.  Basically, the speech-to-text is great as long as you can feed it a list of context-relevant words before every phrase is uttered.  Then after the phrase is uttered, interpreted, and typed into the application, you need to get a fresh list of context-relevant words before the next phrase.

I have a working implementation of this cycle that uses the zsh tab completion system to scrape possible words to pass to the speech-to-text software (https://github.com/rexroni/rexroni-talon).  My next goal is to integrate with a language server client for vim, so that I can accomplish something similar while interacting with vim.

It's easy enough to have a language server wrapper that can bypass vim and scrape certain responses from the language server (like document symbols or completion options).

But when using the speech-to-text software, the 500ms delay before flushing changes to the language server really slows down the cycle of spoken-phrase -> typed-text -> updated-words, and something like 50ms is a bit more reasonable.  Or in the case where a user *only* wants the language server for updaing the speech-to-text software, having a very long timeout and assigning `lsc#file#flushChanges` to a special keybinding (that can be triggered after every phrase is typed) could keep the cpu cost to a bare minimum during periods of normal typing.