### PR TITLE
Make message consuming loop async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 - Use full words for completion item kinds instead of single letters.
 - Avoid overwriting location list if it is in use for something other than LSC
   diagnostics.
+- Asynchronously loop over server messages to avoid long synchronous pauses
+  between handling user input.
 
 # 0.3.2
 


### PR DESCRIPTION
When there are long blocks of messages, especially those which take
significant time to handle, the `while s:Consume` loop could cause very
long periods of synchronous work which cause the appearance of an editor
freeze since they delay the handling of input. Break up the loop with a
zero delay timer in between each message to allow handling user input in
between each one.