### PR TITLE
Run test vim process in temp directories

### DIFF
--- a/test/integration/lib/test_bed.dart
+++ b/test/integration/lib/test_bed.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
 
-import 'package:test/test.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 import 'package:lsp/lsp.dart' show lspChannel;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'vim_remote.dart';
 
@@ -21,7 +22,7 @@ class TestBed {
             onUnhandledError: (error, stack) =>
                 fail('Unhandled server error: $error')))
         .asBroadcastStream();
-    final vim = await Vim.start();
+    final vim = await Vim.start(workingDirectory: d.sandbox);
     await beforeRegister?.call(vim);
     await vim.expr('RegisterLanguageServer("text", {'
         '"command":"localhost:${serverSocket.port}",'
@@ -32,9 +33,7 @@ class TestBed {
 
     addTearDown(() async {
       await vim.quit();
-      final log = File(vim.name);
-      print(await log.readAsString());
-      await log.delete();
+      print(await d.file(vim.name).io.readAsString());
       await serverSocket.close();
     });
     return TestBed._(vim, clients);

--- a/test/integration/pubspec.yaml
+++ b/test/integration/pubspec.yaml
@@ -9,3 +9,4 @@ dependencies:
   lsp: ^0.1.1
   path: ^1.7.0
   test: ^1.13.0
+  test_descriptor: ^1.2.0

--- a/test/integration/test/complete_test.dart
+++ b/test/integration/test/complete_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:_test/stub_lsp.dart';
 import 'package:_test/test_bed.dart';
@@ -26,8 +25,6 @@ void main() {
   tearDown(() async {
     await testBed.vim.sendKeys(':LSClientDisable<cr>');
     await testBed.vim.sendKeys(':%bwipeout!<cr>');
-    final file = File('foo.txt');
-    if (await file.exists()) await file.delete();
     await client.done;
     client = null;
   });

--- a/test/integration/test/did_open_test.dart
+++ b/test/integration/test/did_open_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:async/async.dart';
 import 'package:_test/stub_lsp.dart';
 import 'package:_test/test_bed.dart';
@@ -25,8 +23,6 @@ void main() {
     tearDown(() async {
       await testBed.vim.sendKeys(':LSClientDisable<cr>');
       await testBed.vim.sendKeys(':%bwipeout!<cr>');
-      final file = File('foo.txt');
-      if (await file.exists()) await file.delete();
       await client.done;
       client = null;
     });

--- a/test/integration/test/did_save_test.dart
+++ b/test/integration/test/did_save_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:_test/stub_lsp.dart';
 import 'package:_test/test_bed.dart';
@@ -24,8 +23,6 @@ void main() {
   tearDown(() async {
     await testBed.vim.sendKeys(':LSClientDisable<cr>');
     await testBed.vim.sendKeys(':%bwipeout!<cr>');
-    final file = File('foo.txt');
-    if (await file.exists()) await file.delete();
     await client.done;
     client = null;
   });

--- a/test/integration/test/disabled_server_test.dart
+++ b/test/integration/test/disabled_server_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:_test/stub_lsp.dart';
 import 'package:_test/test_bed.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
@@ -19,8 +17,6 @@ void main() {
     tearDown(() async {
       await testBed.vim.sendKeys(':LSClientDisable<cr>');
       await testBed.vim.sendKeys(':%bwipeout!<cr>');
-      final file = File('foo.txt');
-      if (await file.exists()) await file.delete();
       await client?.done;
     });
 

--- a/test/integration/test/edit_test.dart
+++ b/test/integration/test/edit_test.dart
@@ -25,8 +25,6 @@ void main() {
   tearDown(() async {
     await testBed.vim.sendKeys(':LSClientDisable<cr>');
     await testBed.vim.sendKeys(':%bwipeout!<cr>');
-    final file = File('foo.txt');
-    if (await file.exists()) await file.delete();
     await client.done;
     client = null;
   });

--- a/test/integration/test/workspace_configuration_test.dart
+++ b/test/integration/test/workspace_configuration_test.dart
@@ -25,8 +25,6 @@ void main() {
   tearDown(() async {
     await testBed.vim.sendKeys(':LSClientDisable<cr>');
     await testBed.vim.sendKeys(':%bwipeout!<cr>');
-    final file = File('foo.txt');
-    if (await file.exists()) await file.delete();
     await client.done;
     client = null;
   });


### PR DESCRIPTION
This may resolve some flakiness around multiple test processes
running against the same directory. This will make it easier to test
with more complex project layouts.

- Add a `workingDirectory` argument to `Vim.start`. Use the
  `test_descriptor` sandbox.
- Run vim in the passed working directory initially and when editing
  files.
- Remove per-test file cleanup since `test_descriptor` handles this
  automatically.
- Add a delay after `vim.sendKeys`. Some other timing differences
  surfaced a case where back to back calls to `sendKeys` could cause bad
  interactions.