### PR TITLE
Add argument to `bufnr()` call

### DIFF
--- a/autoload/lsc/file.vim
+++ b/autoload/lsc/file.vim
@@ -34,7 +34,7 @@ function! lsc#file#onOpen() abort
   if has_key(s:file_versions, l:file_path)
     call lsc#file#flushChanges()
   else
-    let l:bufnr = bufnr()
+    let l:bufnr = bufnr('%')
     for l:server in lsc#server#forFileType(&filetype)
       if !get(l:server.config, 'enabled', v:true) | continue | endif
       if l:server.status ==# 'running'


### PR DESCRIPTION
Fixes #387

The argument is required in older versions of vim, and a default of
`'%'` was added since. Add the argument to maintain backwards
compatibility as a best-effort.