### PR TITLE
Add trimming whitespace if snippet enabled

### DIFF
--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -233,7 +233,7 @@ function! s:CompletionItemWord(lsp_item) abort
           \ 'snippet': l:item.word,
           \ 'snippet_trigger': l:item.word
           \ })
-    let l:item.word = a:lsp_item.label
+    let l:item.word = substitute(a:lsp_item.label, '^\s*\|\s*$', '', 'g')
   endif
   return l:item
 endfunction


### PR DESCRIPTION
Fixes #395 

I think we should trim `a:lsp_item.label` always but it would hit performance so this PR applies it only if enabled snippets.
