### PR TITLE
Don't use noselect in completeopt for autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.5.0
+
+**Minor breaking changes**
+- Remove `noselect` from the default `completeopts` used during autocompletion.
+  Re-enable this with `set completeopts+=noselect`. This changes the initial
+  behavior of some keys when autocomplete starts.
+
 # 0.4.0
 
 **Bug fixes**
@@ -21,8 +28,6 @@
   reported.
 
 **Enhancements**
-- Remove `noselect` from the default `completeopts` used during autocompletion.
-  Re-enable this with `set completeopts+=noselect`.
 - More tolerant towards buggy language servers that omit the `result` field on
   response message.
 - Add `g:lsc_autocomplete_length` to configure how many word characters to wait

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   reported.
 
 **Enhancements**
+- Remove `noselect` from the default `completeopts` used during autocompletion.
+  Re-enable this with `set completeopts+=noselect`.
 - More tolerant towards buggy language servers that omit the `result` field on
   response message.
 - Add `g:lsc_autocomplete_length` to configure how many word characters to wait

--- a/autoload/lsc/complete.vim
+++ b/autoload/lsc/complete.vim
@@ -129,7 +129,7 @@ function! s:SetCompleteOpt() abort
     " Set the options that impact behavior for autocomplete use cases without
     " touching other like `preview`
     setl completeopt-=longest
-    setl completeopt+=menu,menuone,noinsert,noselect
+    setl completeopt+=menu,menuone,noinsert
   endif
 endfunction
 

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -260,7 +260,10 @@ When using autocomplete this plugin will modify the buffer local setting
 recommended for a typical autocomplete experience and help to avoid the plugin
 from making changes without a specific user action. Leave
 `g:lsc_auto_completeopt` set to `v:true` (the default) for the recommended
-values.
+values. Some options are left as is, configure `preview`, `popup`,
+`popuphidden`, and `noselect` as preferred in the normal way. See |completeopt|.
+When using this option to override the defaults, be sure to avoid `longest`, and
+include `noinsert`.
 
 It is recommended to avoid other plugins which are attempting to perform
 autocomplete in the same buffer as `vim-lsc`, but if they are used there may

--- a/test/integration/test/complete_test.dart
+++ b/test/integration/test/complete_test.dart
@@ -44,7 +44,7 @@ void main() {
     await server.initialized;
     await testBed.vim.sendKeys('ifoo.');
     await testBed.vim.waitForPopUpMenu();
-    await testBed.vim.sendKeys('a<c-n><esc><esc>');
+    await testBed.vim.sendKeys('a<cr><esc>');
     expect(await testBed.vim.expr('getline(1)'), 'foo.abcd');
   });
 
@@ -61,7 +61,7 @@ void main() {
     await server.initialized;
     await testBed.vim.sendKeys('ifoo');
     await testBed.vim.waitForPopUpMenu();
-    await testBed.vim.sendKeys('b<c-n><esc><esc>');
+    await testBed.vim.sendKeys('b<cr><esc>');
     expect(await testBed.vim.expr('getline(1)'), 'foobar');
   });
 
@@ -78,7 +78,7 @@ void main() {
     await server.initialized;
     await testBed.vim.sendKeys('if<c-x><c-u>');
     await testBed.vim.waitForPopUpMenu();
-    await testBed.vim.sendKeys('<c-n><esc><esc>');
+    await testBed.vim.sendKeys('<cr><esc>');
     expect(await testBed.vim.expr('getline(1)'), 'foobar');
   });
 }


### PR DESCRIPTION
Closes #399

If the users want to automatically choose the first item, that should be
allowed. The old behavior can be restored by adding `noselect` to
`completeopt` outside of the plugin.