### PR TITLE
Handle DocumentHighlightOptions format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   messages from the server.
 - Support the `DocumentHighlightOptions` format for
   `documentHighlightsProvider`.
+- Avoid a state where no document highlights reference calls are made following
+  a server restart.
 
 **Minor breaking changes**
 - Remove `noselect` from the default `completeopts` used during autocompletion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Bug fixes**
 - Fix occasional errors stemming from interleaving the handling of multiple
   messages from the server.
+- Support the `DocumentHighlightOptions` format for
+  `documentHighlightsProvider`.
 
 **Minor breaking changes**
 - Remove `noselect` from the default `completeopts` used during autocompletion.

--- a/autoload/lsc/capabilities.vim
+++ b/autoload/lsc/capabilities.vim
@@ -27,9 +27,12 @@ function! lsc#capabilities#normalize(capabilities) abort
     endif
     let l:normalized.textDocumentSync.incremental = l:incremental
   endif
-  if has_key(a:capabilities, 'documentHighlightProvider')
-    let l:normalized.referenceHighlights =
-        \ a:capabilities.documentHighlightProvider
+  let l:document_highlight_provider =
+      \ get(a:capabilities, 'documentHighlightProvider', v:false)
+  if type(l:document_highlight_provider) == type({})
+    let l:normalized.referenceHighlights = v:true
+  else
+    let l:normalized.referenceHighlights = l:document_highlight_provider
   endif
   return l:normalized
 endfunction

--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -58,14 +58,13 @@ function! s:HighlightReferences(force_in_highlight) abort
   if has_key(s:pending, &filetype) && s:pending[&filetype]
     return
   endif
-  let s:pending[&filetype] = v:true
   let s:highlights_request += 1
   let l:params = lsc#params#documentPosition()
   " TODO handle multiple servers
   let l:server = lsc#server#forFileType(&filetype)[0]
-  call l:server.request('textDocument/documentHighlight', l:params,
-      \ funcref('<SID>HandleHighlights',
-      \ [s:highlights_request, getcurpos(), bufnr('%'), &filetype]))
+  let s:pending[&filetype] = l:server.request('textDocument/documentHighlight',
+      \ l:params, funcref('<SID>HandleHighlights',
+      \   [s:highlights_request, getcurpos(), bufnr('%'), &filetype]))
 endfunction
 
 function! s:CanHighlightReferences() abort

--- a/test/integration/test/highlight_test.dart
+++ b/test/integration/test/highlight_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:_test/stub_lsp.dart';
+import 'package:_test/test_bed.dart';
+import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:test/test.dart';
+
+void main() {
+  TestBed testBed;
+  Peer client;
+
+  setUpAll(() async {
+    testBed = await TestBed.setup();
+  });
+
+  setUp(() async {
+    final nextClient = testBed.clients.first;
+    await testBed.vim.edit('foo.txt');
+    await testBed.vim.sendKeys(':LSClientEnable<cr>');
+    client = await nextClient;
+  });
+
+  tearDown(() async {
+    await testBed.vim.sendKeys(':LSClientDisable<cr>');
+    await testBed.vim.sendKeys(':%bwipeout!<cr>');
+    await client.done;
+    client = null;
+  });
+
+  test('requests highlights with bool capability', () async {
+    final server = StubServer(client, capabilities: {
+      'documentHighlightProvider': true,
+    });
+    final callMade = Completer<void>();
+    server.peer.registerMethod('textDocument/documentHighlight',
+        (Parameters params) {
+      callMade.complete();
+      return [];
+    });
+    await server.initialized;
+    expect(callMade.future, completes);
+  });
+
+  test('requests highlights with map capability', () async {
+    final server = StubServer(client, capabilities: {
+      'documentHighlightProvider': true,
+    });
+    final callMade = Completer<void>();
+    server.peer.registerMethod('textDocument/documentHighlight',
+        (Parameters params) {
+      callMade.complete();
+      return [];
+    });
+    await server.initialized;
+    expect(callMade.future, completes);
+  });
+}


### PR DESCRIPTION
Fixes #401

The older spec used only `bool` for this option, but newer versions
allow a configuration which can enable progress support.