### PR TITLE
Make the OnExit callback synchronous

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -280,7 +280,7 @@ function! lsc#server#register(filetype, config) abort
   endfunction
   function! l:server._initialize(params, callback) abort
     let l:params = lsc#config#messageHook(l:self, 'initialize', a:params)
-    call l:self._channel.request('initialize', l:params, a:callback)
+    call l:self._channel.request('initialize', l:params, a:callback, {})
   endfunction
   function! l:server.on_err(message) abort
     if get(l:self.config, 'suppress_stderr', v:false) | return | endif

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -86,7 +86,7 @@ function! s:Kill(server, status, OnExit) abort
     endif
     if a:OnExit != v:null | call a:OnExit() | endif
   endfunction
-  return a:server.request('shutdown', v:null, funcref('Exit'))
+  return a:server.request('shutdown', v:null, funcref('Exit'), {'sync': v:true})
 endfunction
 
 function! lsc#server#restart() abort
@@ -259,12 +259,13 @@ function! lsc#server#register(filetype, config) abort
       \ 'capabilities': lsc#capabilities#defaults()
       \}
   let l:server.languageId[a:filetype] = l:languageId
-  function! l:server.request(method, params, callback) abort
+  function! l:server.request(method, params, callback, ...) abort
     if l:self.status !=# 'running' | return v:false | endif
     let l:params = lsc#config#messageHook(l:self, a:method, a:params)
     if l:params is lsc#config#skip() | return v:false | endif
     let l:Callback = lsc#config#responseHook(l:self, a:method, a:callback)
-    call l:self._channel.request(a:method, l:params, l:Callback)
+    let l:options = a:0 > 0 ? a:1 : {}
+    call l:self._channel.request(a:method, l:params, l:Callback, l:options)
     return v:true
   endfunction
   function! l:server.notify(method, params) abort

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -151,3 +151,23 @@ endfunction
 
 function! lsc#util#noop() abort
 endfunction
+
+function! lsc#util#async(Callback) abort
+  return funcref('<Sid>Async', [a:Callback])
+endfunction
+
+function! s:Async(Callback, ...) abort
+  call timer_start(0, funcref('<SID>IgnoreArgs', [a:Callback, a:000]))
+endfunction
+
+function! s:IgnoreArgs(Callback, args, ...) abort
+  try
+    call call(a:Callback, a:args)
+  catch
+    call lsc#message#error('Error with callback: '.string(a:Callback)."\n"
+        \ .string(v:exception))
+    let g:lsc_last_error = v:exception
+    let g:lsc_last_throwpoint = v:throwpoint
+    let g:lsc_last_error_callback = [a:Callback, a:args]
+  endtry
+endfunction


### PR DESCRIPTION
Fixes #406

The channel callbacks may occur during a `sleep`, however timers will
not fire. When all request callbacks were moved behind a timer, the
callback to the `'shutdown'` request was never invoked so despite a
server response the client would always hit the timeout condition.

Add a `lsc#util#async` utility to wrap individual callbacks behind a
function that delays them with a zero length timer. Use this wrapper by
default for callbacks, but allow an options dict to specify `'sync'`.