### PR TITLE
Avoid public names for temporary callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   `documentHighlightsProvider`.
 - Avoid a state where no document highlights reference calls are made following
   a server restart.
+- Avoid creating public functions for callbacks which should be temporary.
 
 **Minor breaking changes**
 - Remove `noselect` from the default `completeopts` used during autocompletion.


### PR DESCRIPTION
Change locally redefined functions to instead bind additional arguments
in a `funcref` with a script private function.