### PR TITLE
Don't concatenate as many strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 **Enhancements**
 - Improve performance when the language server sends many diagnostics updates.
+- Improve performance for periods of high message throughput.
 
 # 0.4.0
 

--- a/autoload/lsc/protocol.vim
+++ b/autoload/lsc/protocol.vim
@@ -85,11 +85,11 @@ function! s:Consume(server) abort
     return s:Incomplete(l:buffer)
   endif
   if len(l:message) == l:message_end
-    let l:payload = l:message[l:message_start:]
+    let l:payload = l:message[l:message_start :]
     call remove(l:buffer, 0)
   else
-    let l:payload = l:message[l:message_start:l:message_end-1]
-    let l:buffer[0] = l:message[l:message_end:]
+    let l:payload = l:message[l:message_start : l:message_end-1]
+    let l:buffer[0] = l:message[l:message_end :]
   endif
   try
     if len(l:payload) > 0

--- a/autoload/lsc/protocol.vim
+++ b/autoload/lsc/protocol.vim
@@ -3,7 +3,7 @@ function! lsc#protocol#open(command, on_message, on_err, on_exit) abort
       \ '_call_id': 0,
       \ '_in': [],
       \ '_out': [],
-      \ '_buffer': '',
+      \ '_buffer': [],
       \ '_on_message': lsc#util#async(a:on_message),
       \ '_callbacks': {},
       \}
@@ -28,7 +28,7 @@ function! lsc#protocol#open(command, on_message, on_err, on_exit) abort
     call l:self._channel.send(s:Encode(a:message))
   endfunction
   function! l:c._recieve(message) abort
-    let l:self._buffer .= a:message
+    call add(l:self._buffer, a:message)
     if has_key(l:self, '_consume') | return | endif
     if s:Consume(l:self)
       let l:self._consume = timer_start(0,
@@ -67,25 +67,30 @@ function! s:Encode(message) abort
   return 'Content-Length: '.l:length."\r\n\r\n".l:encoded
 endfunction
 
-" Reads from the buffer for server_name and processes the message. Continues to
-" process messages until the buffer is empty. Does nothing if a complete message
-" is not available.
+" Reads from the buffer for [server] and processes a message, if one is
+" available.
+"
+" Returns true if there are more messages to consume in the buffer.
 function! s:Consume(server) abort
-  let l:message = a:server._buffer
+  let l:buffer = a:server._buffer
+  let l:message = l:buffer[0]
   let l:end_of_header = stridx(l:message, "\r\n\r\n")
   if l:end_of_header < 0
-    return v:false
+    return s:Incomplete(l:buffer)
   endif
   let l:headers = split(l:message[:l:end_of_header - 1], "\r\n")
   let l:message_start = l:end_of_header + len("\r\n\r\n")
   let l:message_end = l:message_start + s:ContentLength(l:headers)
   if len(l:message) < l:message_end
-    " Wait for the rest of the message to get buffered
-    return v:false
+    return s:Incomplete(l:buffer)
   endif
-  let l:payload = l:message[l:message_start : l:message_end-1]
-  let l:remaining_message = l:message[l:message_end : ]
-  let a:server._buffer = l:remaining_message
+  if len(l:message) == l:message_end
+    let l:payload = l:message[l:message_start:]
+    call remove(l:buffer, 0)
+  else
+    let l:payload = l:message[l:message_start:l:message_end-1]
+    let l:buffer[0] = l:message[l:message_end:]
+  endif
   try
     if len(l:payload) > 0
       let l:content = json_decode(l:payload)
@@ -101,7 +106,16 @@ function! s:Consume(server) abort
     call lsc#util#shift(a:server._out, 10, l:content)
     call s:Dispatch(l:content, a:server._on_message, a:server._callbacks)
   endif
-  return l:remaining_message !=# ''
+  return !empty(l:buffer)
+endfunction
+
+function! s:Incomplete(buffer) abort
+  if len(a:buffer) == 1 | return v:false | endif
+  " Merge 2 messages
+  let l:first = remove(a:buffer, 0)
+  let l:second = remove(a:buffer, 0)
+  call insert(a:buffer, l:first.l:second)
+  return v:true
 endfunction
 
 " Finds the header with 'Content-Length' and returns the integer value


### PR DESCRIPTION
String concatenation gets more and more expensive the longer the strings
get. In a period of high throughput messages from the server, where
processing is not keeping up with the rate of message delivery, the cost
of concatenating a longer and longer buffer string becomes overwhelming.

Store the buffer as a list of strings. Only concatenate strings in cases
where a single message spans multiple chunks in the buffer, otherwise
consume messages within each chunk.

There are still some string splicing operations which dominate the
runtime of this method, but the cost is much much smaller than it used
to be. Processing throughput is much higher and bottlenecked on the
request callbacks.

In an extreme cases this makes a drastic difference.

Before:

```
 count  total (s)   self (s)  function
 3173 277.953046 277.656509  <SNR>97_Consume()
```

After:

```
 count  total (s)   self (s)  function
 4927   1.456195   0.985914  <SNR>97_Consume()
```