### PR TITLE
Shorten callback names for error message

### DIFF
--- a/autoload/lsc/protocol.vim
+++ b/autoload/lsc/protocol.vim
@@ -4,7 +4,7 @@ function! lsc#protocol#open(command, on_message, on_err, on_exit) abort
       \ '_in': [],
       \ '_out': [],
       \ '_buffer': [],
-      \ '_on_message': lsc#util#async(a:on_message),
+      \ '_on_message': lsc#util#async('message handler', a:on_message),
       \ '_callbacks': {},
       \}
   function! l:c.request(method, params, callback, options) abort
@@ -12,7 +12,7 @@ function! lsc#protocol#open(command, on_message, on_err, on_exit) abort
     let l:message = s:Format(a:method, a:params, l:self._call_id)
     let l:self._callbacks[l:self._call_id] = get(a:options, 'sync', v:false)
         \ ? [a:callback]
-        \ : [lsc#util#async(a:callback)]
+        \ : [lsc#util#async('request callback for '.a:method, a:callback)]
     call l:self._send(l:message)
   endfunction
   function! l:c.notify(method, params) abort

--- a/autoload/lsc/util.vim
+++ b/autoload/lsc/util.vim
@@ -152,20 +152,19 @@ endfunction
 function! lsc#util#noop() abort
 endfunction
 
-function! lsc#util#async(Callback) abort
-  return funcref('<Sid>Async', [a:Callback])
+function! lsc#util#async(name, Callback) abort
+  return funcref('<Sid>Async', [a:name, a:Callback])
 endfunction
 
-function! s:Async(Callback, ...) abort
-  call timer_start(0, funcref('<SID>IgnoreArgs', [a:Callback, a:000]))
+function! s:Async(name, Callback, ...) abort
+  call timer_start(0, funcref('<SID>IgnoreArgs', [a:name, a:Callback, a:000]))
 endfunction
 
-function! s:IgnoreArgs(Callback, args, ...) abort
+function! s:IgnoreArgs(name, Callback, args, ...) abort
   try
     call call(a:Callback, a:args)
   catch
-    call lsc#message#error('Error with callback: '.string(a:Callback)."\n"
-        \ .string(v:exception))
+    call lsc#message#error('Error from '.a:name.': '.string(v:exception))
     let g:lsc_last_error = v:exception
     let g:lsc_last_throwpoint = v:throwpoint
     let g:lsc_last_error_callback = [a:Callback, a:args]


### PR DESCRIPTION
When a `funcref` is a partial the `string()` result includes the
arguments, which in the case of a server dict can be quite large. Pass a
more human readable name.