### PR TITLE
Fix Undefined variable: g:lsc_enable_diagnosticsa

### DIFF
--- a/autoload/lsc/diagnostics.vim
+++ b/autoload/lsc/diagnostics.vim
@@ -62,7 +62,7 @@ function! lsc#diagnostics#forFile(file_path) abort
 endfunction
 
 function! lsc#diagnostics#setForFile(file_path, diagnostics) abort
-  if (exists('g:lsc_enable_diagnostics') && !g:lsc_enable_diagnosticsa)
+  if (exists('g:lsc_enable_diagnostics') && !g:lsc_enable_diagnostics)
       \ || (empty(a:diagnostics) && !has_key(s:file_diagnostics, a:file_path))
     return
   endif


### PR DESCRIPTION
I updated the plugin today and got this error frequently:
> [lsc:Error] Error from message handler: 'Vim(if):E121: Undefined variable: g:lsc_enable_diagnosticsa'

It seems to be a typo so I opened this PR which fixes the issue.

Thanks!