### PR TITLE
Fix cursor position following multibyte characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Avoid a state where no document highlights reference calls are made following
   a server restart.
 - Avoid creating public functions for callbacks which should be temporary.
+- Fix character positions when the cursor is on a line following multibyte
+  characters for recent versions of vim. Older versions and neovim continue to
+  have incorrect positions.
 
 **Minor breaking changes**
 - Remove `noselect` from the default `completeopts` used during autocompletion.

--- a/autoload/lsc/params.vim
+++ b/autoload/lsc/params.vim
@@ -2,16 +2,31 @@ function! lsc#params#textDocument() abort
   return {'textDocument': {'uri': lsc#uri#documentUri()}}
 endfunction
 
-function! lsc#params#documentPosition() abort
-  return { 'textDocument': {'uri': lsc#uri#documentUri()},
-      \ 'position': {'line': line('.') - 1, 'character': col('.') - 1}
-      \ }
-endfunction
-
-function! lsc#params#documentRange() abort
-  return { 'textDocument': {'uri': lsc#uri#documentUri()},
-      \ 'range': {
-      \   'start': {'line': line('.') - 1, 'character': col('.') - 1},
-      \   'end': {'line': line('.') - 1, 'character': col('.')}},
-      \ }
-endfunction
+if exists('*charcol')
+  function! lsc#params#documentPosition() abort
+    return { 'textDocument': {'uri': lsc#uri#documentUri()},
+        \ 'position': {'line': line('.') - 1, 'character': charcol('.') - 1}
+        \ }
+  endfunction
+  function! lsc#params#documentRange() abort
+    return { 'textDocument': {'uri': lsc#uri#documentUri()},
+        \ 'range': {
+          \   'start': {'line': line('.') - 1, 'character': charcol('.') - 1},
+          \   'end': {'line': line('.') - 1, 'character': charcol('.')}},
+          \ }
+  endfunction
+else
+  " TODO - this is broken following multibyte characters.
+  function! lsc#params#documentPosition() abort
+    return { 'textDocument': {'uri': lsc#uri#documentUri()},
+        \ 'position': {'line': line('.') - 1, 'character': col('.') - 1}
+        \ }
+  endfunction
+  function! lsc#params#documentRange() abort
+    return { 'textDocument': {'uri': lsc#uri#documentUri()},
+        \ 'range': {
+          \   'start': {'line': line('.') - 1, 'character': col('.') - 1},
+          \   'end': {'line': line('.') - 1, 'character': col('.')}},
+          \ }
+  endfunction
+endif


### PR DESCRIPTION
Closes #427

Use `charcol` over `col` where it exists.
Gate the function definition behind the feature check to avoid repeating
it for every call.