### PR TITLE
Fix edits in non-current buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Avoid a state where no document highlights reference calls are made following
   a server restart.
 - Avoid creating public functions for callbacks which should be temporary.
+- Fix file edits in buffers that aren't current when the current buffer is
+  shorter than the buffer being edited.
 
 **Minor breaking changes**
 - Remove `noselect` from the default `completeopts` used during autocompletion.


### PR DESCRIPTION
A change to better handle edits which claim to be past the end of the
file used the current buffer to determine how long the file is, but the
current buffer is not necessarily the one with edits.

Move the opening of the buffer outside of the built up command so that
it happens before computing the rest of the command and `line('$')` is
accurate.

Move `keepjumps` and `keepalt` to the calling code instead of repeating
them in each function. Drop the second `keepjumps` since the entire
process should be handled.