### PR TITLE
Deepcopy server output for logs

### DIFF
--- a/autoload/lsc/protocol.vim
+++ b/autoload/lsc/protocol.vim
@@ -107,7 +107,7 @@ function! s:Consume(server) abort
     call lsc#message#error('Could not decode message: ['.l:payload.']')
   endtry
   if exists('l:content')
-    call lsc#util#shift(a:server._out, s:log_size, l:content)
+    call lsc#util#shift(a:server._out, s:log_size, deepcopy(l:content))
     call s:Dispatch(l:content, a:server._on_message, a:server._callbacks)
   endif
   return !empty(l:buffer)


### PR DESCRIPTION
The edit functionality can modify the data which is confusing when the
server log doesn't show what the server sent. Make a deep copy of output
for the log.
Input is assumed safe for reuse.