### PR TITLE
Add support for disabling highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 **Enhancements**
 - Improve performance when the language server sends many diagnostics updates.
 - Improve performance for periods of high message throughput.
+- Add `g:lsc_diagnostic_highlights` config, and commands to enable and disable
+  diagnostic highlights.
 
 # 0.4.0
 

--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -14,6 +14,7 @@ function! lsc#cursor#onWinEnter() abort
 endfunction
 
 function! lsc#cursor#showDiagnostic() abort
+  if !get(g:, 'lsc_diagnostic_highlights', v:true) | return | endif
   let l:diagnostic = lsc#diagnostics#underCursor()
   if has_key(l:diagnostic, 'message')
     let l:max_width = &columns - 1 " Avoid edge of terminal

--- a/autoload/lsc/highlights.vim
+++ b/autoload/lsc/highlights.vim
@@ -7,6 +7,7 @@ endfunction
 
 " Refresh highlight matches in the current window.
 function! lsc#highlights#update() abort
+  if !get(g:, 'lsc_diagnostic_highlights', v:true) | return | endif
   if s:CurrentWindowIsFresh() | return | endif
   call lsc#highlights#clear()
   if &diff | return | endif

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -160,13 +160,18 @@ updated any time diagnostics change, until the quickfix list is set by some
 other command.
 
                                                 *:LSClientWindowDiagnostics*
-By default vim-lsc will create a location list for every window with an LSC
-tracked buffer open. In the typical case |:lopen| is sufficient to see a
-continuously updated list of diagnostics for the current buffer.
+By default vim-lsc will create and maintain a location list with the diagnostics
+for every window with an LSC tracked buffer open. In the typical case |:lopen|
+is sufficient to see a continuously updated list of diagnostics for the current
+buffer.
 
 If the current location list for a window is in use for another list it will not
 be overwritten. The `:LSClientWindowDiagnostics` command will restore the LSC
 diagnostics to the location list.
+
+Tip: While the diagnostics list is the active location list for the window
+|:lafter| and |:lbefore| will jump to the next and previous diagnostic around
+the cursor.
 
 The LSC diagnostics list is always kept up to day as long as it still exists on
 the location list stack. Use |:lolder|, |:lnewer|, or |:lhistory| to switch
@@ -180,6 +185,15 @@ list.
 Echo the full text of all diagnostics on the current line. Useful when a
 diagnostic has been truncated or there are multiple diagnostics on a line and
 otherwise only the diagnostic closest to the cursor is shown.
+
+                                                *:LSClientDisableDiagnosticHighlights*
+Turn off highglighting of diagnostics, and stop echoing messages form
+diagnostics on the same line as the cursor.
+
+                                                *:LSClientEnableDiagnosticHighlights*
+Turn on highlighting of diagnostics, and start echoing messages from diagnostics
+on the same line as the cursor. Does nothing if |g:lsc_enable_diagnostics| is
+`v:false`.
 
                                                 *:LSClientRestartServer*
 Sends requests to the server for the current filetype to "shutdown" and
@@ -303,20 +317,28 @@ example:
 <
 
                                                 *lsc-configure-diagnostics*
+                                                *g:lsc_diagnostic_highlights*
+By default diagnostics are highlighted according to their severity and
+diagnostic messages are echoed when the cursor is on a line with a diagnostic.
+To disable these features, set `g:lsc_diagnostic_highlights` to `v:false`.
+Diagnostics can still be accessed from the location list by default (see
+|:LSClientWindowDiagnostics|) or from the quickfix list after using
+|:LSClientAllDiagnostics|. To disable diagnostics entirely see
+|g:lsc_enable_diagnostics|.
+
+Diagnostic highlightss can be turned on or off any time with
+|:LSClientEnableDiagnosticHighlights| and |:LSClientDisableDiagnosticHighlights|
+
                                                 *g:lsc_enable_diagnostics*
-Diagnostics highlighting and location list updating is enabled by default. To
-disable diagnostic tracking set `g:lsc_enable_diagnostics` to `v:false`. With
-diagnostics disabled |:LSClientAllDiagnostics| will never surface any results.
-The server may communicate diagnostics but they will be ignored. Changing this
-configuration while a server is running may have unexpected results, if it is
-changed use |:LSClientRestartServer|.
+Disable diagnostic entirely by setting `g:lsc_enable_diagnostics` to `v:false`.
+When diagnostics are disabled there will not be any highlighting or echoing of
+diagnostics while editing, and |:LSClientWindowDiagnostics| and
+|:LSClientAllDiagnostics| will not work. To disable only the highlights and echo
+of diagnostics, see |g:lsc_diagnostic_highlights| or
+|:LSClientDisableDiagnosticHighlights|.
 
-If the location list is in use by a list other than the LSC diagnostics you
-won't see updates as diagnostics change. Call |:LSClientWindowDiagnostics| to
-restore the LSC diagnostics list.
-
-While vim-lsc is maintaining the location list |:lbefore| and |:lafter| will
-jump to the previous or next diagnostic around the cursor.
+Changing this configuration while a server is running may have unexpected
+results, if it is changed use |:LSClientRestartServer|.
 
                                                 *lsc-configure-hover*
                                                 *g:lsc_preview_split_direction*

--- a/plugin/lsc.vim
+++ b/plugin/lsc.vim
@@ -42,6 +42,8 @@ command! LSClientSignatureHelp call lsc#signaturehelp#getSignatureHelp()
 command! LSClientRestartServer call <SID>IfEnabled('lsc#server#restart')
 command! LSClientDisable call lsc#server#disable()
 command! LSClientEnable call lsc#server#enable()
+command! LSClientDisableDiagnosticHighlights call <SID>DisableHighlights()
+command! LSClientEnableDiagnosticHighlights call <SID>EnableHighlights()
 
 if !exists('g:lsc_enable_apply_edit') || g:lsc_enable_apply_edit
   command! -nargs=? LSClientRename call lsc#edit#rename(<args>)
@@ -85,6 +87,16 @@ function! s:BuffersOfType(filetype) abort
     endif
   endfor
   return l:buffers
+endfunction
+
+function! s:DisableHighlights() abort
+  let g:lsc_enable_highlights = v:false
+  call lsc#util#winDo('call lsc#highlights#clear()')
+endfunction
+
+function! s:EnableHighlights() abort
+  let g:lsc_enable_highlights = v:true
+  call lsc#util#winDo('call lsc#highlights#update()')
 endfunction
 
 augroup LSC


### PR DESCRIPTION
Closes #100

Allow using the diagnostics in the location and quickfix lists without
the visual noise of highlighting and echoing messages while moving
around the buffer.

- Add support for a `g:lsc_diagnostic_highlights` variable to disable
  highlights.
- Add `:LSClientDisableDiagnosticHighlights` and one to enable to flip
  the config and ensure that the current highlighting state gets set
  correctly.
- Add a doc section on the new variable and each new command.
- Move the tip about `:lafter` to the doc for
  `:LSClientWindowDiagnostics` and rephrase the first paragraph.