### PR TITLE
Add g:lsc_block_complete_triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Improve performance for periods of high message throughput.
 - Add `g:lsc_diagnostic_highlights` config, and commands to enable and disable
   diagnostic highlights.
+- Add `g:lsc_block_complete_triggers` to override server config and disable
+  autocomplete after specific characters.
 
 # 0.4.0
 

--- a/autoload/lsc/capabilities.vim
+++ b/autoload/lsc/capabilities.vim
@@ -11,6 +11,11 @@ function! lsc#capabilities#normalize(capabilities) abort
     if has_key(l:completion_provider, 'triggerCharacters')
       let l:normalized.completion.triggerCharacters =
           \ l:completion_provider['triggerCharacters']
+      let l:blocked = get(g:, 'lsc_block_complete_triggers', [])
+      if !empty(l:blocked)
+        call filter(l:normalized.completion.triggerCharacters,
+            \ 'index(l:blocked, v:val) < 0')
+      endif
     endif
   endif
   if has_key(a:capabilities, 'textDocumentSync')

--- a/doc/lsc.txt
+++ b/doc/lsc.txt
@@ -267,6 +267,16 @@ automatically close the preview window after completion use the following:
  autocmd CompleteDone * silent! pclose
 <
 
+                                                *g:lsc_block_complete_triggers*
+Language Servers configure the characters that trigger autocomplete. In some
+cases a server may enable autocomplete for characters which are commonly
+followed by a newline, but the `<enter>` key gets captured by the popupmenu.
+Disable autocomplete for selected characters, overriding server configuration,
+with:
+>
+ let g:lsc_block_complete_triggers = ['{']
+<
+
                                                 *lsc-configure-completeopt*
                                                 *g:lsc_auto_completeopt*
 When using autocomplete this plugin will modify the buffer local setting


### PR DESCRIPTION
Closes #444

Allows configuring a list of characters which are ignored if any server
enables them as triggers for autocomplete.

Works around a situation where typing `<enter>` quickly after a trigger
character like `{` does not insert a newline.

Always return to normal mode during teardown in the autocomplete test.
This means that if a test fails in a way where it leaves the editor in
insert mode, like checking an expectation before sending the `<esc>`, it
doesn't time out the overall test.