### PR TITLE
Don't run diagnostic hightlights if lsc_enable_diagnostics is false

### DIFF
--- a/autoload/lsc/cursor.vim
+++ b/autoload/lsc/cursor.vim
@@ -14,6 +14,7 @@ function! lsc#cursor#onWinEnter() abort
 endfunction
 
 function! lsc#cursor#showDiagnostic() abort
+  if !get(g:, 'lsc_enable_diagnostics', v:true) | return | endif
   if !get(g:, 'lsc_diagnostic_highlights', v:true) | return | endif
   let l:diagnostic = lsc#diagnostics#underCursor()
   if has_key(l:diagnostic, 'message')

--- a/autoload/lsc/highlights.vim
+++ b/autoload/lsc/highlights.vim
@@ -7,6 +7,7 @@ endfunction
 
 " Refresh highlight matches in the current window.
 function! lsc#highlights#update() abort
+  if !get(g:, 'lsc_enable_diagnostics', v:true) | return | endif
   if !get(g:, 'lsc_diagnostic_highlights', v:true) | return | endif
   if s:CurrentWindowIsFresh() | return | endif
   call lsc#highlights#clear()


### PR DESCRIPTION
It would only check lsc_diagnostic_highlights, so "disabling diagnostic"
intuitively requires setting two variables.

This was causing problems for me since lsc#cursor#showDiagnostic() does
echo '', which cleared text in the cmdline windows from somewhere else.