### PR TITLE
Percent encoding

### DIFF
--- a/autoload/lsc/uri.vim
+++ b/autoload/lsc/uri.vim
@@ -16,7 +16,7 @@ function! s:EncodePath(value) abort
   " (https://github.com/tpope/vim-unimpaired/blob/master/plugin/unimpaired.vim#L461)
   " This follows the VIM License over at https://github.com/vim/vim/blob/master/LICENSE
   return substitute(iconv(a:value, "latin-1", 'utf-8'),
-        \ '[^A-Za-z0-9_.~-]',
+        \ '[^a-zA-Z0-9-_.~/]',
         \ '\=s:EncodeChar(submatch(0))', 'g')
 endfunction
 

--- a/autoload/lsc/uri.vim
+++ b/autoload/lsc/uri.vim
@@ -27,15 +27,8 @@ endfunction
 
 function! s:DecodePath(value) abort
   " shamelessly taken from Mr. T. Pope and adapted:
-  " (https://github.com/tpope/vim-unimpaired/blob/master/plugin/unimpaired.vim#L465-L466)
+  " (https://github.com/tpope/vim-unimpaired/blob/master/plugin/unimpaired.vim#L466)
   " This follows the VIM License over at https://github.com/vim/vim/blob/master/LICENSE
-  let str = substitute(
-        \ substitute(
-        \   substitute(a:value,'%0[Aa]\n$','%0A',''),
-        \   '%0[Aa]',
-        \   '\n',
-        \   'g')
-        \,'+',' ','g')
   return iconv(
         \ substitute(
         \   str,

--- a/autoload/lsc/uri.vim
+++ b/autoload/lsc/uri.vim
@@ -31,7 +31,7 @@ function! s:DecodePath(value) abort
   " This follows the VIM License over at https://github.com/vim/vim/blob/master/LICENSE
   return iconv(
         \ substitute(
-        \   str,
+        \   a:value,
         \   '%\(\x\x\)',
         \   '\=nr2char("0x".submatch(1))','g'),
         \ 'utf-8',

--- a/autoload/lsc/uri.vim
+++ b/autoload/lsc/uri.vim
@@ -12,8 +12,12 @@ function! lsc#uri#documentPath(uri) abort
 endfunction
 
 function! s:EncodePath(value) abort
-  return substitute(a:value, '\([^a-zA-Z0-9-_.~/]\)',
-      \ '\=s:EncodeChar(submatch(1))', 'g')
+  " shamelessly taken from Mr. T. Pope and adapted:
+  " (https://github.com/tpope/vim-unimpaired/blob/master/plugin/unimpaired.vim#L461)
+  " This follows the VIM License over at https://github.com/vim/vim/blob/master/LICENSE
+  return substitute(iconv(a:value, "latin-1", 'utf-8'),
+        \ '[^A-Za-z0-9_.~-]',
+        \ '\=s:EncodeChar(submatch(0))', 'g')
 endfunction
 
 function! s:EncodeChar(char) abort
@@ -22,13 +26,23 @@ function! s:EncodeChar(char) abort
 endfunction
 
 function! s:DecodePath(value) abort
-  return substitute(a:value, '%\([a-fA-F0-9]\{2}\)',
-      \ '\=s:DecodeChar(submatch(1))', 'g')
-endfunction
-
-function! s:DecodeChar(hexcode) abort
-  let l:charcode = str2nr(a:hexcode, 16)
-  return nr2char(l:charcode)
+  " shamelessly taken from Mr. T. Pope and adapted:
+  " (https://github.com/tpope/vim-unimpaired/blob/master/plugin/unimpaired.vim#L465-L466)
+  " This follows the VIM License over at https://github.com/vim/vim/blob/master/LICENSE
+  let str = substitute(
+        \ substitute(
+        \   substitute(a:value,'%0[Aa]\n$','%0A',''),
+        \   '%0[Aa]',
+        \   '\n',
+        \   'g')
+        \,'+',' ','g')
+  return iconv(
+        \ substitute(
+        \   str,
+        \   '%\(\x\x\)',
+        \   '\=nr2char("0x".submatch(1))','g'),
+        \ 'utf-8',
+        \ 'latin1')
 endfunction
 
 function! s:filePrefix(...) abort


### PR DESCRIPTION
> Disclaimer: I have not studied the referred rfc. I just spotted the differing behaviour to other language server clients. And wanted to make vim-lsc act accordingly.

*- replaces PR #455 -*

The Language Server Protocol refers to https://www.rfc-editor.org/rfc/rfc3986.

When converting a file-path into an URI, transported via UTF-8 (as by the encoding for messages to the server), it used a percentage encoding but with fewer bytes represented.

The following: `file:///Ümläutö`
was encoded in: `file:///%dcml%e4ut%f6`
now it encodes to: `file:///%c3%9cml%c3%a4ut%c3%b6`

Decoding was adapted accordingly.

---
Credit to: Mr. Tim Pope - https://github.com/tpope/vim-unimpaired/blob/master/plugin/unimpaired.vim

I quickly looked for existing solutions via iconv. Mr. Tim Pope has such available under the VIM License. This should be compatible but I am not a lawyer.
Maybe @tpope allows the usage.

Otherwise I could update the implementation with a handwritten en-/decoder.