### PR TITLE
DRAFT: make vim-lsc publish its diagnostic capabilities

### DIFF
--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -197,6 +197,7 @@ function! s:ClientCapabilities() abort
     \   },
     \   'hover': {'contentFormat': ['plaintext', 'markdown']},
     \   'signatureHelp': {'dynamicRegistration': v:false},
+    \   'publishDiagnostics': v:true,
     \ }
     \}
 endfunction

--- a/autoload/lsc/server.vim
+++ b/autoload/lsc/server.vim
@@ -197,7 +197,12 @@ function! s:ClientCapabilities() abort
     \   },
     \   'hover': {'contentFormat': ['plaintext', 'markdown']},
     \   'signatureHelp': {'dynamicRegistration': v:false},
-    \   'publishDiagnostics': v:true,
+    \   'publishDiagnostics': {
+    \     'relatedInformation': v:false,
+    \     'versionSupport': v:false,
+    \     'codeDescriptionSupport': v:false,
+    \     'dataSupport': v:false,
+    \   },
     \ }
     \}
 endfunction


### PR DESCRIPTION
vim-lsc did not prompt to support diagnostics but simply relied on retrieveing notifications.
We have to further explore notifications sent from the server: vim-lsc shall be upfront about its capabiltiies; Otherwise they are missed.